### PR TITLE
fix broken search filters

### DIFF
--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/__init__.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/__init__.py
@@ -46,6 +46,7 @@ import types
 import re
 import time
 import sys
+import inspect
 import traceback
 
 import ipaddr
@@ -1415,7 +1416,18 @@ class simpleLdap(object):
 
 	@classmethod
 	def rewrite_filter(cls, filter, mapping):
+		property_ = univention.admin.modules.get(cls.module).property_descriptions.get(filter.variable)
+		if property_ and not isinstance(filter.value, (list, tuple)):
+			if property_.multivalue:
+				# special case: mutlivalue properties need to be a list when map()-ing
+				filter.value = [filter.value]
+			if issubclass(property_.syntax if inspect.isclass(property_.syntax) else type(property_.syntax), univention.admin.syntax.complex):
+				# special case: complex syntax properties need to be a list (of lists, if multivalue)
+				filter.value = [filter.value]
 		univention.admin.mapping.mapRewrite(filter, mapping)
+		if isinstance(filter.value, (list, tuple)) and filter.value:
+			# complex syntax
+			filter.value = filter.value[0]
 
 
 class simpleComputer(simpleLdap):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/__init__.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/__init__.py
@@ -1395,7 +1395,10 @@ class simpleLdap(object):
 
 	@classmethod
 	def lookup(cls, co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-		filter_str = unicode(cls.lookup_filter(filter_s, lo) or '')
+		filter_s = cls.lookup_filter(filter_s, lo)
+		if superordinate:
+			filter_s = cls.lookup_filter_superordinate(filter_s, superordinate)
+		filter_str = unicode(filter_s or '')
 		result = []
 		for dn, attrs in lo.search(filter_str, base, scope, [], unique, required, timeout, sizelimit):
 			try:
@@ -1409,6 +1412,10 @@ class simpleLdap(object):
 		filter_p = cls.unmapped_lookup_filter()
 		filter_p.append_unmapped_filter_string(filter_s, cls.rewrite_filter, univention.admin.modules.get(cls.module).mapping)
 		return filter_p
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		return filter
 
 	@classmethod
 	def unmapped_lookup_filter(cls):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/container/cn.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/container/cn.py
@@ -298,26 +298,17 @@ class object(univention.admin.handlers.simpleLdap):
 				changes.append((attr, self.dn, ''))
 		self.lo.modify(self.default_dn, changes)
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'organizationalRole'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('cn', 'univention')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionBase')])
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'organizationalRole'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('cn', 'univention')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionBase')])
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'organizationalRole' in attr.get('objectClass', []) and not attr.get('cn', []) == ['univention'] and 'univentionBase' not in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/container/dc.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/container/dc.py
@@ -193,21 +193,14 @@ class object(univention.admin.handlers.simpleLdap):
 			self['dnsForwardZone'] = self.lo.searchDn(base=self.dn, scope='domain', filter='(&(objectClass=dNSZone)(relativeDomainName=@)(!(zoneName=*.in-addr.arpa)))')
 			self['dnsReverseZone'] = self.lo.searchDn(base=self.dn, scope='domain', filter='(&(objectClass=dNSZone)(relativeDomainName=@)(zoneName=*.in-addr.arpa))')
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionBase'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionBase'),
-	])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/container/ou.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/container/ou.py
@@ -311,25 +311,16 @@ class object(univention.admin.handlers.simpleLdap):
 				changes.append((attr, self.dn, ''))
 		self.lo.modify(self.default_dn, changes)
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'organizationalUnit'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionBase')])
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'organizationalUnit'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionBase')])
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'organizationalUnit' in attr.get('objectClass', []) and 'univentionBase' not in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dhcp/pool.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dhcp/pool.py
@@ -224,7 +224,7 @@ class object(DHCPBase):
 			filter.value = '%s %s' % (filter.value.strip('*'), values[filter.variable])
 			filter.variable = 'dhcpPermitList'
 		else:
-			univention.admin.mapping.mapRewrite(filter, mapping)
+			super(object, cls).rewrite_filter(filter, mapping)
 
 
 def identify(dn, attr):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dhcp/server.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dhcp/server.py
@@ -110,19 +110,15 @@ class object(DHCPBase):
 		])
 
 	@classmethod
-	def lookup(cls, co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-		filter_obj = cls.lookup_filter(filter_s)
+	def lookup_filter_superordinate(cls, filter, superordinate):
 		if superordinate:
-			filter_obj.expressions.append(univention.admin.filter.expression('dhcpServiceDN', superordinate.dn, escape=True))
-		filter_str = unicode(filter_obj)
-
-		return super(object, cls).lookup(co, lo, filter_str, base, superordinate, scope, unique, required, timeout, sizelimit)
+			filter.expressions.append(univention.admin.filter.expression('dhcpServiceDN', superordinate.dn, escape=True))
+		return filter
 
 
 def identify(dn, attr):
 	return 'dhcpServer' in attr.get('objectClass', [])
 
-#lookup_filter = object.lookup_filter  # if we specify lookup_filter here the superordinate is not evaluated
-
 
 lookup = object.lookup
+lookup_filter = object.lookup_filter

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/alias.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/alias.py
@@ -136,31 +136,25 @@ class object(univention.admin.handlers.simpleLdap):
 	def _ldap_post_remove(self):
 		self._updateZone()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'dNSZone'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.in-addr.arpa')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aRecord', '*')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.ip6.arpa')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aAAARecord', '*')]),
+			univention.admin.filter.expression('cNAMERecord', '*')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope="sub", unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'dNSZone'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.in-addr.arpa')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aRecord', '*')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.ip6.arpa')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aAAARecord', '*')]),
-		univention.admin.filter.expression('cNAMERecord', '*')
-	])
-
-	if superordinate:
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
 		filter.expressions.append(univention.admin.filter.expression('zoneName', superordinate.mapping.mapValue('zone', superordinate['zone']), escape=True))
+		return filter
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
 
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append((object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs)))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/forward_zone.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/forward_zone.py
@@ -325,26 +325,18 @@ class object(univention.admin.handlers.simpleLdap):
 		if not self.hasChanged('serial'):
 			self['serial'] = str(int(self['serial']) + 1)
 
-
-def lookup_filter(filter_s=None, lo=None):
-	lookup_filter_obj = \
-		univention.admin.filter.conjunction('&', [
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
 			univention.admin.filter.expression('objectClass', 'dNSZone'),
 			univention.admin.filter.expression('relativeDomainName', '@'),
 			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*%s' % ARPA_IP4)]),
 			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*%s' % ARPA_IP6)]),
 		])
-	lookup_filter_obj.append_unmapped_filter_string(filter_s, univention.admin.mapping.mapRewrite, mapping)
-	return lookup_filter_obj
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = lookup_filter(filter_s)
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append((object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs)))
-	return res
+lookup = object.lookup
+lookup_filter = object.lookup_filter
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/ptr_record.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/ptr_record.py
@@ -214,32 +214,22 @@ class object(univention.admin.handlers.simpleLdap):
 	def _ldap_post_remove(self):
 		self._updateZone()
 
-
-def lookup(co, lo, filter_s, base='', superordinate=None, scope="sub", unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'dNSZone'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
-		univention.admin.filter.conjunction('|', [
-			univention.admin.filter.expression('zoneName', '*.in-addr.arpa'),
-			univention.admin.filter.expression('zoneName', '*.ip6.arpa'),
-		]),
-	])
-
-	if superordinate:
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
 		filter.expressions.append(univention.admin.filter.expression('zoneName', superordinate.mapping.mapValue('subnet', superordinate['subnet']), escape=True))
+		filter = rewrite_rev(filter, superordinate.info['subnet'])
+		return filter
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		if superordinate:
-			filter_p = rewrite_rev(filter_p, superordinate.info['subnet'])
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append((object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs)))
-	return res
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'dNSZone'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
+			univention.admin.filter.conjunction('|', [
+				univention.admin.filter.expression('zoneName', '*.in-addr.arpa'),
+				univention.admin.filter.expression('zoneName', '*.ip6.arpa'),
+			]),
+		])
 
 
 def rewrite_rev(filter, subnet):
@@ -288,6 +278,9 @@ def rewrite_rev(filter, subnet):
 			expression('relativeDomainName', addr_host or '*'),
 		])
 	return filter
+
+
+lookup = object.lookup
 
 
 def identify(dn, attr):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/reverse_zone.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/reverse_zone.py
@@ -284,10 +284,9 @@ class object(univention.admin.handlers.simpleLdap):
 			rdn_value = rdn[rdn.find('=') + 1:]
 			return unmapSubnet(rdn_value)
 
-
-def lookup_filter(filter_s=None, lo=None):
-	lookup_filter_obj = \
-		univention.admin.filter.conjunction('&', [
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
 			univention.admin.filter.expression('objectClass', 'dNSZone'),
 			univention.admin.filter.expression('relativeDomainName', '@'),
 			univention.admin.filter.conjunction('|', [
@@ -295,28 +294,19 @@ def lookup_filter(filter_s=None, lo=None):
 				univention.admin.filter.expression('zoneName', '*%s' % ARPA_IP6)
 			]),
 		])
-	lookup_filter_obj.append_unmapped_filter_string(filter_s, univention.admin.mapping.mapRewrite, mapping)
-	return lookup_filter_obj
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = lookup_filter(filter_s)
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append((object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs)))
-	return res
+lookup = object.lookup
+lookup_filter = object.lookup_filter
 
 
 def identify(dn, attr):
-
 	return 'dNSZone' in attr.get('objectClass', []) and\
 		['@'] == attr.get('relativeDomainName', []) and\
 		(attr['zoneName'][0].endswith(ARPA_IP4) or attr['zoneName'][0].endswith(ARPA_IP6))
 
 
 def quickDescription(rdn):
-
 	return unmapSubnet(rdn)
 
 

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/srv_record.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/srv_record.py
@@ -161,29 +161,23 @@ class object(univention.admin.handlers.simpleLdap):
 	def _ldap_post_remove(self):
 		self._updateZone()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'dNSZone'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.in-addr.arpa')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.ip6.arpa')]),
+			univention.admin.filter.expression('sRVRecord', '*'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope="sub", unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'dNSZone'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.in-addr.arpa')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.ip6.arpa')]),
-		univention.admin.filter.expression('sRVRecord', '*'),
-	])
-
-	if superordinate:
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
 		filter.expressions.append(univention.admin.filter.expression('zoneName', superordinate.mapping.mapValue('zone', superordinate['zone']), escape=True))
+		return filter
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
 
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append((object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs)))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/txt_record.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/dns/txt_record.py
@@ -130,33 +130,27 @@ class object(univention.admin.handlers.simpleLdap):
 	def _ldap_post_remove(self):
 		self._updateZone()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'dNSZone'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.in-addr.arpa')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('cNAMERecord', '*')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('sRVRecord', '*')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aRecord', '*')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aAAARecord', '*')]),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('mXRecord', '*')]),
+			univention.admin.filter.expression('tXTRecord', '*')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope="sub", unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'dNSZone'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('relativeDomainName', '@')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('zoneName', '*.in-addr.arpa')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('cNAMERecord', '*')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('sRVRecord', '*')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aRecord', '*')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('aAAARecord', '*')]),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('mXRecord', '*')]),
-		univention.admin.filter.expression('tXTRecord', '*')
-	])
-
-	if superordinate:
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
 		filter.expressions.append(univention.admin.filter.expression('zoneName', superordinate.mapping.mapValue('zone', superordinate['zone']), escape=True))
+		return filter
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
 
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append((object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs)))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/groups/group.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/groups/group.py
@@ -1033,27 +1033,19 @@ class object(univention.admin.handlers.simpleLdap):
 				self.lo.modify(dn, [('sambaPrimaryGroupSID', attr.get('sambaPrimaryGroupSID', []), [newSid])])
 			self.update_sambaPrimaryGroupSid = False
 
-
-def lookup_filter(filter_s=None, lo=None):
-	lookup_filter_obj = \
-		univention.admin.filter.conjunction('&', [
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
 			univention.admin.filter.expression('cn', '*'),
 			univention.admin.filter.conjunction('|', [
 				univention.admin.filter.conjunction('&', [univention.admin.filter.expression('objectClass', 'univentionGroup'), ]),
 				univention.admin.filter.conjunction('&', [univention.admin.filter.expression('objectClass', 'sambaGroupMapping'), ])
 			])
 		])
-	lookup_filter_obj.append_unmapped_filter_string(filter_s, univention.admin.mapping.mapRewrite, mapping)
-	return lookup_filter_obj
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = lookup_filter(filter_s)
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
+lookup_filter = object.lookup_filter
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/kerberos/kdcentry.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/kerberos/kdcentry.py
@@ -212,29 +212,19 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'top'),
+			univention.admin.filter.expression('objectClass', 'account'),
+			univention.admin.filter.expression('objectClass', 'krb5Principal'),
+			univention.admin.filter.expression('objectClass', 'krb5KDCEntry'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'top'),
-		univention.admin.filter.expression('objectClass', 'account'),
-		univention.admin.filter.expression('objectClass', 'krb5Principal'),
-		univention.admin.filter.expression('objectClass', 'krb5KDCEntry'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	ocs = attr.get('objectClass', [])
-
 	return 'top' in ocs and 'account' in ocs and 'krb5Principal' in ocs and 'krb5KDCEntry' in ocs

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/mail/domain.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/mail/domain.py
@@ -96,23 +96,15 @@ class object(univention.admin.handlers.simpleLdap):
 		ml = [(a, b, c.lower()) if a == "cn" else (a, b, c) for (a, b, c) in ml]
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('cn', '*'),
+			univention.admin.filter.expression('objectClass', 'univentionMailDomainname')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('cn', '*'),
-		univention.admin.filter.expression('objectClass', 'univentionMailDomainname')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/mail/folder.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/mail/folder.py
@@ -278,23 +278,15 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('cn', '*'),
+			univention.admin.filter.expression('objectClass', 'univentionMailSharedFolder')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('cn', '*'),
-		univention.admin.filter.expression('objectClass', 'univentionMailSharedFolder')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/mail/lists.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/mail/lists.py
@@ -198,24 +198,15 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionMailList')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionMailList')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionMailList' in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/nagios/service.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/nagios/service.py
@@ -364,21 +364,14 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionNagiosServiceClass'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionNagiosServiceClass'),
-	])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/nagios/timeperiod.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/nagios/timeperiod.py
@@ -249,21 +249,14 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionNagiosTimeperiodClass'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionNagiosTimeperiodClass'),
-	])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/networks/network.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/networks/network.py
@@ -312,25 +312,14 @@ class object(univention.admin.handlers.simpleLdap):
 			if ipaddr.IPAddress(self['ipRange'][i][0]) < ipaddr.IPAddress(self['ipRange'][i - 1][0]):
 				self.sort_ipranges()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionNetworkClass'),
+		])
 
-def rewrite(filter, mapping):
-	univention.admin.mapping.mapRewrite(filter, mapping)
 
-
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionNetworkClass'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, rewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/admin_container.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/admin_container.py
@@ -121,19 +121,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyAdminContainerSettings')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyAdminContainerSettings')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/autostart.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/autostart.py
@@ -121,19 +121,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyAutoStart')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyAutoStart')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/desktop.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/desktop.py
@@ -160,19 +160,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDesktop')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDesktop')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_boot.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_boot.py
@@ -134,21 +134,15 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpBoot'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpBoot'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionPolicyDhcpBoot' in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_dns.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_dns.py
@@ -134,19 +134,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpDns'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpDns'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_dnsupdate.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_dnsupdate.py
@@ -209,19 +209,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpDnsUpdate'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpDnsUpdate'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_leasetime.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_leasetime.py
@@ -153,18 +153,14 @@ class object(univention.admin.handlers.simplePolicy):
 			if not ((key == 'lease_time_min' or key == 'lease_time_max' or key == 'lease_time_default') and value[0] == ''):
 				univention.admin.handlers.simplePolicy.__setitem__(self, key, value)
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpLeaseTime'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpLeaseTime'),
-	])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_netbios.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_netbios.py
@@ -146,19 +146,11 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
-
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpNetbios'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpNetbios'),
+		])
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_routing.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_routing.py
@@ -121,19 +121,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpRouting'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpRouting'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_scope.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_scope.py
@@ -171,19 +171,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpScope'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpScope'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_statements.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/dhcp_statements.py
@@ -183,19 +183,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpStatements'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyDhcpStatements'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/ldapserver.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/ldapserver.py
@@ -124,19 +124,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyLDAPServer')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyLDAPServer')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/maintenance.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/maintenance.py
@@ -269,19 +269,14 @@ class object(univention.admin.handlers.simplePolicy):
 			ml.append(('univentionCron', self.oldattr.get('univentionCron', []), [cron]))
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyInstallationTime')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyInstallationTime')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/masterpackages.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/masterpackages.py
@@ -137,19 +137,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyPackagesMaster')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyPackagesMaster')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/memberpackages.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/memberpackages.py
@@ -137,19 +137,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyPackagesMember')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyPackagesMember')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/nfsmounts.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/nfsmounts.py
@@ -133,19 +133,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyNFSMounts')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyNFSMounts')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/print_quota.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/print_quota.py
@@ -188,19 +188,14 @@ class object(univention.admin.handlers.simplePolicy):
 				if len(user_dn) < 1 and entry[2] != 'root':
 					raise univention.admin.uexceptions.notValidUser(_('%s is not valid. ') % entry[2])
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicySharePrintQuota')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicySharePrintQuota')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/printserver.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/printserver.py
@@ -124,19 +124,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyPrintServer')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyPrintServer')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/pwhistory.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/pwhistory.py
@@ -161,19 +161,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyPWHistory')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyPWHistory')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/registry.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/registry.py
@@ -173,19 +173,14 @@ class object(univention.admin.handlers.simplePolicy):
 		self.polinfo = univention.admin.mapping.mapDict(self.mapping, values)
 		self.polinfo = self._post_unmap(self.polinfo, values)
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyRegistry'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyRegistry'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/release.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/release.py
@@ -136,19 +136,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyUpdate')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyUpdate')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/repositoryserver.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/repositoryserver.py
@@ -125,19 +125,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyRepositoryServer')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyRepositoryServer')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/repositorysync.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/repositorysync.py
@@ -222,19 +222,14 @@ class object(univention.admin.handlers.simplePolicy):
 			ml.append(('univentionRepositoryCron', self.oldattr.get('univentionRepositoryCron', []), [cron]))
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyRepositorySync')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyRepositorySync')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/share_userquota.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/share_userquota.py
@@ -175,19 +175,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyShareUserQuota')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyShareUserQuota')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/slavepackages.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/slavepackages.py
@@ -137,19 +137,14 @@ register_policy_mapping(mapping)
 class object(univention.admin.handlers.simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPolicyPackagesSlave')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPolicyPackagesSlave')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/umc.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/policies/umc.py
@@ -124,19 +124,14 @@ register_policy_mapping(mapping)
 class object(simplePolicy):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return udm_filter.conjunction('&', [
+			udm_filter.expression('objectClass', 'umcPolicy')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = udm_filter.conjunction('&', [
-		udm_filter.expression('objectClass', 'umcPolicy')
-	])
-
-	if filter_s:
-		filter_p = udm_filter.parse(filter_s)
-		udm_filter.walk(filter_p, udm_mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/cn.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/cn.py
@@ -76,25 +76,16 @@ mapping.register('name', 'cn', None, univention.admin.mapping.ListToString)
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'organizationalRole'),
+			univention.admin.filter.expression('cn', 'univention')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'organizationalRole'),
-		univention.admin.filter.expression('cn', 'univention')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'organizationalRole' in attr.get('objectClass', []) and attr.get('cn', []) == ['univention']

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/default.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/default.py
@@ -186,24 +186,15 @@ class object(univention.admin.handlers.simpleLdap):
 	def _ldap_dn(self):
 		return 'cn=default containers,cn=univention,%s' % (self.position.getDomain())
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionDefault')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionDefault')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionDefault' in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/directory.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/directory.py
@@ -246,24 +246,15 @@ class object(univention.admin.handlers.simpleLdap):
 		dn = ldap.dn.str2dn(super(object, self)._ldap_dn())
 		return '%s,cn=univention,%s' % (ldap.dn.dn2str(dn[0]), self.position.getDomain())
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionDirectory')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionDirectory')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionDirectory' in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/extended_attribute.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/extended_attribute.py
@@ -530,25 +530,16 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionUDMProperty'),
+			univention.admin.filter.expression('univentionUDMPropertyVersion', '2'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionUDMProperty'),
-		univention.admin.filter.expression('univentionUDMPropertyVersion', '2'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionUDMProperty' in attr.get('objectClass', []) and attr.get('univentionUDMPropertyVersion', ['0'])[0] == '2'

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/extended_options.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/extended_options.py
@@ -223,19 +223,14 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionUDMOption')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionUDMOption')
-	])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = [object(co, lo, None, dn, attributes=attrs) for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit)]
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=False):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/ldapacl.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/ldapacl.py
@@ -197,24 +197,15 @@ class object(univention.admin.handlers.simpleLdap):
 			if not apt.apt_pkg.version_compare(self['packageversion'], old_version) > -1:
 				raise univention.admin.uexceptions.valueInvalidSyntax(_('packageversion: Version must not be lower than the current one.'))
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', OC),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', OC),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return OC in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/ldapschema.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/ldapschema.py
@@ -171,24 +171,15 @@ class object(univention.admin.handlers.simpleLdap):
 			if not apt.apt_pkg.version_compare(self['packageversion'], old_version) > -1:
 				raise univention.admin.uexceptions.valueInvalidSyntax(_('packageversion: Version must not be lower than the current one.'))
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', OC),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', OC),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return OC in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/license.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/license.py
@@ -354,19 +354,14 @@ class object(univention.admin.handlers.simpleLdap):
 
 		self.save()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionLicense')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionLicense')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/lock.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/lock.py
@@ -94,20 +94,11 @@ mapping.register('locktime', 'lockTime', None, univention.admin.mapping.ListToSt
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
-
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'lock')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'lock')
+		])
 
 
-def identify(dn, attr, canonical=0):
-	return 'lock' in attr.get('objectClass', [])
+lookup = object.lookup

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/packages.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/packages.py
@@ -96,19 +96,14 @@ mapping.register('packageList', 'univentionPackageDefinition')
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPackageList')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPackageList')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/portal.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/portal.py
@@ -242,22 +242,14 @@ class object(univention.admin.handlers.simpleLdap):
 			obj['portal'] = [x for x in obj.info.get('portal', []) + [self.dn] if not self.lo.compare_dn(x, olddn)]
 			obj.modify()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', OC),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', OC),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/portal_entry.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/portal_entry.py
@@ -216,22 +216,14 @@ mapping.register('icon', 'univentionPortalEntryIcon', None, univention.admin.map
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', OC),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', OC),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/printermodel.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/printermodel.py
@@ -111,26 +111,21 @@ mapping.register('printmodel', 'printerModel', mapDriverList, unmapDriverList)
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def rewrite_filter(cls, filter, mapping):
+		if filter.variable == 'printmodel':
+			filter.variable = 'printerModel'
+		else:
+			super(object, cls).rewrite_filter(filter, mapping)
 
-def rewrite(filter, mapping):
-	if filter.variable == 'printmodel':
-		filter.variable = 'printerModel'
-	else:
-		univention.admin.mapping.mapRewrite(filter, mapping)
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPrinterModels')
+		])
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPrinterModels')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, rewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/printeruri.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/printeruri.py
@@ -98,19 +98,14 @@ mapping.register('printeruri', 'printerURI')
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPrinterURIs')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPrinterURIs')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/prohibited_username.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/prohibited_username.py
@@ -96,19 +96,14 @@ mapping.register('usernames', 'prohibitedUsername', None, None)
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionProhibitedUsernames')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionProhibitedUsernames')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/sambaconfig.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/sambaconfig.py
@@ -218,25 +218,16 @@ mapping.register('refuseMachinePWChange', 'univentionSambaRefuseMachinePWChange'
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionSambaConfig'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionDomain')]),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionSambaConfig'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionDomain')]),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionSambaConfig' in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/sambadomain.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/sambadomain.py
@@ -366,25 +366,16 @@ class object(univention.admin.handlers.simpleLdap):
 		if not props == int(self.get('domainPwdProperties', 0)):
 			self['domainPwdProperties'] = str(props)
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'sambaDomain'),
+			univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionDomain')]),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'sambaDomain'),
-		univention.admin.filter.conjunction('!', [univention.admin.filter.expression('objectClass', 'univentionDomain')]),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'sambaDomain' in attr.get('objectClass', []) and 'univentionDomain' not in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/service.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/service.py
@@ -81,24 +81,15 @@ mapping.register('name', 'cn', None, univention.admin.mapping.ListToString)
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionServiceObject'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionServiceObject'),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionServiceObject' in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/syntax.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/syntax.py
@@ -242,19 +242,12 @@ class object(univention.admin.handlers.simpleLdap):
 
 		return ml
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.expression('objectClass', 'univentionSyntax')
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.expression('objectClass', 'univentionSyntax')
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/udm_hook.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/udm_hook.py
@@ -247,24 +247,15 @@ class object(univention.admin.handlers.simpleLdap):
 				break
 		return modlist
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', OC),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', OC),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return OC in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/udm_module.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/udm_module.py
@@ -271,24 +271,15 @@ class object(univention.admin.handlers.simpleLdap):
 				break
 		return modlist
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', OC),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', OC),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return OC in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/udm_syntax.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/udm_syntax.py
@@ -247,24 +247,15 @@ class object(univention.admin.handlers.simpleLdap):
 				break
 		return modlist
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', OC),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', OC),
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return OC in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/umc_operationset.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/umc_operationset.py
@@ -153,19 +153,14 @@ mapping.register('hosts', 'umcOperationSetHost')
 class object(simpleLdap):
 	module = module
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return udm_filter.conjunction('&', [
+			udm_filter.expression('objectClass', 'umcOperationSet')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = udm_filter.conjunction('&', [
-		udm_filter.expression('objectClass', 'umcOperationSet')
-	])
-
-	if filter_s:
-		filter_p = udm_filter.parse(filter_s)
-		udm_filter.walk(filter_p, udm_mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	return object.lookup(co, lo, filter, base, superordinate, scope, unique, required, timeout, sizelimit)
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/usertemplate.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/usertemplate.py
@@ -466,20 +466,14 @@ class object(univention.admin.handlers.simpleLdap, mungeddial.Support):
 		self.sambaMungedDialUnmap()
 		self.sambaMungedDialParse()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionUserTemplate')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=superordinate, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionUserTemplate')])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/xconfig_choices.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/settings/xconfig_choices.py
@@ -207,24 +207,15 @@ class object(univention.admin.handlers.simpleLdap):
 		dn = ldap.dn.str2dn(super(object, self)._ldap_dn())
 		return '%s,cn=univention,%s' % (ldap.dn.dn2str(dn[0]), self.position.getDomain())
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionXConfigurationChoices')
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionXConfigurationChoices')
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn, attributes=attrs))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):
-
 	return 'univentionXConfigurationChoices' in attr.get('objectClass', [])

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/shares/printer.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/shares/printer.py
@@ -357,21 +357,14 @@ class object(univention.admin.handlers.simpleLdap):
 			printergroup_object['groupMember'].remove(self.info['name'])
 			printergroup_object.modify()
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPrinter'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPrinter'),
-	])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn in lo.searchDn(unicode(filter), base, scope, unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/shares/printergroup.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/shares/printergroup.py
@@ -210,21 +210,14 @@ class object(univention.admin.handlers.simpleLdap):
 			if not self.lo.searchDn(filter='(&(objectClass=univentionPrinter)(cn=%s)%s)' % (escape_filter_chars(member), spoolhosts)):
 				raise univention.admin.uexceptions.notValidPrinter(_('%(name)s is not a valid printer on Spoolhost %(host)s.') % {'name': member, 'host': self.info['spoolHost']})
 
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
+			univention.admin.filter.expression('objectClass', 'univentionPrinterGroup'),
+		])
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', 'univentionPrinterGroup'),
-	])
 
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn in lo.searchDn(unicode(filter), base, scope, unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn))
-	return res
+lookup = object.lookup
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-directory-manager-modules/modules/univention/admin/handlers/shares/share.py
+++ b/management/univention-directory-manager-modules/modules/univention/admin/handlers/shares/share.py
@@ -53,7 +53,7 @@ class cscPolicy(univention.admin.syntax.select):
 module = 'shares/share'
 operations = ['add', 'edit', 'remove', 'search', 'move']
 
-syntax_filter = univention.admin.filter.conjunction('&', [
+syntax_return univention.admin.filter.conjunction('&', [
 	univention.admin.filter.expression('objectClass', 'univentionShare'),
 	univention.admin.filter.expression('cn', '*'),
 	univention.admin.filter.expression('writeable', '1'),
@@ -884,23 +884,16 @@ class object(univention.admin.handlers.simpleLdap):
 				'samba': options['samba'].short_description,
 				'nfs': options['nfs'].short_description})
 
-
-def lookup_filter(filter_s=None, lo=None):
-	lookup_filter_obj = \
-		univention.admin.filter.conjunction('&', [
+	@classmethod
+	def unmapped_lookup_filter(cls):
+		return univention.admin.filter.conjunction('&', [
 			univention.admin.filter.expression('objectClass', 'univentionShare'),
 			univention.admin.filter.expression('cn', '*'),
 		])
-	lookup_filter_obj.append_unmapped_filter_string(filter_s, univention.admin.mapping.mapRewrite, mapping)
-	return lookup_filter_obj
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = lookup_filter(filter_s)
-	res = []
-	for dn in lo.searchDn(unicode(filter), base, scope, unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn))
-	return res
+lookup = object.lookup
+lookup_filter = object.lookup_filter
 
 
 def identify(dn, attr, canonical=0):

--- a/management/univention-management-console-module-udm/umc/python/udm/__init__.py
+++ b/management/univention-management-console-module-udm/umc/python/udm/__init__.py
@@ -135,6 +135,29 @@ class ObjectPropertySanitizer(StringSanitizer):
 		StringSanitizer.__init__(self, **args)
 
 
+class PropertySearchSanitizer(LDAPSearchSanitizer):
+
+	def _sanitize(self, value, name, further_arguments):
+		object_type = further_arguments.get('objectType')
+		property_ = further_arguments.get('objectProperty')
+		add_asterisks, use_asterisks = self.add_asterisks, self.use_asterisks
+		if object_type and property_ and UDM_Module(object_type).module:
+			prop = UDM_Module(object_type).module.property_descriptions.get(property_)
+			# If the widget is a checkbox the frontend sends True/False.
+			# We need to make sure that the sanitizer rewrites this to "1" and "0" without adding asterisks.
+			if prop and prop.syntax.name == 'boolean':
+				self.use_asterisks = False
+				self.add_asterisks = False
+				if value is True:
+					value = '1'
+				elif value is False:
+					value = '0'
+		try:
+			return super(PropertySearchSanitizer, self)._sanitize(value, name, further_arguments)
+		finally:
+			self.add_asterisks, self.use_asterisks = add_asterisks, use_asterisks
+
+
 class Instance(Base, ProgressMixin):
 
 	def __init__(self):
@@ -512,9 +535,10 @@ class Instance(Base, ProgressMixin):
 		return result
 
 	@sanitize(
-		objectPropertyValue=LDAPSearchSanitizer(
+		objectPropertyValue=PropertySearchSanitizer(
 			add_asterisks=ADD_ASTERISKS,
 			use_asterisks=USE_ASTERISKS,
+			further_arguments=['objectType', 'objectProperty'],
 		),
 		objectProperty=ObjectPropertySanitizer(required=True),
 		fields=ListSanitizer(),


### PR DESCRIPTION
https://forge.univention.org/bugzilla/show_bug.cgi?id=40672
This pull request fixes all broken search filters in UDM, which are causing wrong search results:
The fix does this in a generic fashion, it's not necessary to adjust any mapping/unmapping function.
Basically now all UDM handlers are using the generic lookup() method of simpleLDAP.
That generic lookup method doesn't produce errors in search filters for boolean values, complex syntax values, multi-value properties, combobox selections.