### PR TITLE
Bug #46279: systemd/journald/SplitMode

### DIFF
--- a/base/univention-base-files/conffiles/etc/systemd/journald.conf
+++ b/base/univention-base-files/conffiles/etc/systemd/journald.conf
@@ -17,8 +17,13 @@ else:
 	print "Storage=%s" % (value, )
 @!@#Compress=yes
 #Seal=yes
-#SplitMode=uid
-#SyncIntervalSec=5m
+@!@
+value = configRegistry.get('systemd/journald/SplitMode')
+if value is None:
+	print "#SplitMode=uid"
+else:
+	print "SplitMode=%s" % (value, )
+@!@#SyncIntervalSec=5m
 #RateLimitInterval=30s
 #RateLimitBurst=1000
 @!@

--- a/base/univention-base-files/debian/univention-base-files.univention-config-registry
+++ b/base/univention-base-files/debian/univention-base-files.univention-config-registry
@@ -36,6 +36,7 @@ Variables: auth/methods
 
 Type: file
 File: etc/systemd/journald.conf
+Variables: systemd/journald/SplitMode
 Variables: systemd/journald/Storage
 Variables: systemd/journald/SystemMaxUse
 Variables: systemd/journald/SystemKeepFree

--- a/base/univention-base-files/debian/univention-base-files.univention-config-registry-variables
+++ b/base/univention-base-files/debian/univention-base-files.univention-config-registry-variables
@@ -118,6 +118,12 @@ Description[en]=Specifies additional configuration options for /etc/ssh/sshd_con
 Type=bool
 Categories=service-ssh
 
+[systemd/journald/SplitMode]
+Description[de]=Definiert, wie journald die Protokolldateien aufteilt. Standard: uid. Siehe `man journald.conf für Details.
+Description[en]=Specifices how journald splits up journal files. Default: uid. See man `man journald.conf` for details.
+Type=str
+Categories=system-base
+
 [systemd/journald/Storage]
 Description[de]=Entweder "volatile", "persistent", "auto" oder "none". Standard ist "auto".
 Description[en]=One of "volatile", "persistent", "auto" and "none". Defaults to "auto".


### PR DESCRIPTION
OK, so let's see how this goes, being my first pull request to your repository, please bear with me, I might not have made everything correctly.

## Please make sure you considered the following things

- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

http://forge.univention.org/bugzilla/show_bug.cgi?id=46279

## Description of the changes

Allows to control how systemd's journald splits into individual
journal files. Sometimes uid just is to much and i.e. login is
plain enough on system where users don't actively log in to but
use remote services.

* **What kind of change does this PR introduce?** feature
* **How can we reproduce the issue?** 
  * ucr commit /etc/systemd/journald.conf without additions should not change current systems.
  * Setting any allowed value as defined in [journald.conf(5)](https://www.freedesktop.org/software/systemd/man/journald.conf.html), redo ucr commit and restarting systemd-journald should suffice
* **To which UCS version does the issue apply?** 4.2-3 and (but not tested) 4.3-0
* **Please list relevant screenshots, error messages, logs or tracebacks** (If not already in the bugzilla)
* **Are there any breaking or API changes?** Not that I know of.
* **Are there changes in the documentation necessary?** Not that I think it is needed.
* **Are there descriptions for newly introduced UCR variables?** Yes, see in the pull request.
