### PR TITLE
Bug #46791: misleading description of umc/web/piwik corrected

### DIFF
--- a/management/univention-management-console/debian/univention-management-console-frontend.univention-config-registry-variables
+++ b/management/univention-management-console/debian/univention-management-console-frontend.univention-config-registry-variables
@@ -17,8 +17,8 @@ Type=str
 Categories=management-umc
 
 [umc/web/piwik]
-Description[de]=Ist diese Option aktiviert, werden bei Verwendung der Univention Core License (die in der Regel für Evaluationen von UCS herangezogen wird) anonyme Nutzungsstatistiken zur Verwendung der UMC erzeugt. Die aufgerufenen Module werden dabei von einer Instanz des Web-Traffic-Analyse-Tools Piwik protokolliert. Dies ermöglicht es Univention die Entwicklung besser auf das Kundeninteresse zuzuschneiden und Usability-Verbesserungen vorzunehmen.
-Description[en]=If this option is activated, anonymous usage statistics on the use of the UMC are collected when using the Univention Core License (which is generally used for evaluating UCS). The modules opened are logged in an instance of the web traffic analysis tool Piwik. This allows Univention to tailor the development better to customer needs and carry out usability improvements.
+Description[de]=Ist diese Variaoder nicht oder nicht auf 'false' gesetzt, werden bei Verwendung der Univention Core License (die in der Regel für Evaluationen von UCS herangezogen wird) anonyme Nutzungsstatistiken zur Verwendung der UMC erzeugt. Die aufgerufenen Module werden dabei von einer Instanz des Web-Traffic-Analyse-Tools Piwik protokolliert. Dies ermöglicht es Univention die Entwicklung besser auf das Kundeninteresse zuzuschneiden und Usability-Verbesserungen vorzunehmen.
+Description[en]=If this option is unset or not set to 'false', anonymous usage statistics on the use of the UMC are collected when using the Univention Core License (which is generally used for evaluating UCS). The modules opened are logged in an instance of the web traffic analysis tool Piwik. This allows Univention to tailor the development better to customer needs and carry out usability improvements.
 Type=bool
 Categories=management-umc
 

--- a/management/univention-management-console/debian/univention-management-console-frontend.univention-config-registry-variables
+++ b/management/univention-management-console/debian/univention-management-console-frontend.univention-config-registry-variables
@@ -17,7 +17,7 @@ Type=str
 Categories=management-umc
 
 [umc/web/piwik]
-Description[de]=Ist diese Variaoder nicht oder nicht auf 'false' gesetzt, werden bei Verwendung der Univention Core License (die in der Regel für Evaluationen von UCS herangezogen wird) anonyme Nutzungsstatistiken zur Verwendung der UMC erzeugt. Die aufgerufenen Module werden dabei von einer Instanz des Web-Traffic-Analyse-Tools Piwik protokolliert. Dies ermöglicht es Univention die Entwicklung besser auf das Kundeninteresse zuzuschneiden und Usability-Verbesserungen vorzunehmen.
+Description[de]=Ist diese Variable nicht oder nicht auf 'false' gesetzt, werden bei Verwendung der Univention Core License (die in der Regel für Evaluationen von UCS herangezogen wird) anonyme Nutzungsstatistiken zur Verwendung der UMC erzeugt. Die aufgerufenen Module werden dabei von einer Instanz des Web-Traffic-Analyse-Tools Piwik protokolliert. Dies ermöglicht es Univention die Entwicklung besser auf das Kundeninteresse zuzuschneiden und Usability-Verbesserungen vorzunehmen.
 Description[en]=If this option is unset or not set to 'false', anonymous usage statistics on the use of the UMC are collected when using the Univention Core License (which is generally used for evaluating UCS). The modules opened are logged in an instance of the web traffic analysis tool Piwik. This allows Univention to tailor the development better to customer needs and carry out usability improvements.
 Type=bool
 Categories=management-umc


### PR DESCRIPTION
Thank you for providing a pull request!

## Please make sure you considered the following things

- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=46791

## Description of the changes

Description of umc/web/piwik is misleading about the default settings: fixed
