### PR TITLE
Bug #48422 Add a listener mdb size check

### DIFF
--- a/nagios/univention-nagios/debian/rules
+++ b/nagios/univention-nagios/debian/rules
@@ -35,6 +35,7 @@ override_dh_auto_build:
 	dh_auto_build
 	gcc -o usr/lib/nagios/plugins/check_univention_joinstatus_suidwrapper usr/lib/nagios/plugins/check_univention_joinstatus_suidwrapper.c
 	gcc -o usr/lib/nagios/plugins/check_univention_ldap_suidwrapper       usr/lib/nagios/plugins/check_univention_ldap_suidwrapper.c
+	gcc -o usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper.c
 	gcc -o usr/lib/nagios/plugins/check_univention_winbind_suidwrapper usr/lib/nagios/plugins/check_univention_winbind_suidwrapper.c
 	gcc -o usr/lib/nagios/plugins/check_univention_nscd_suidwrapper usr/lib/nagios/plugins/check_univention_nscd_suidwrapper.c
 	gcc -o usr/lib/nagios/plugins/check_univention_slapd_mdb_maxsize_suidwrapper usr/lib/nagios/plugins/check_univention_slapd_mdb_maxsize_suidwrapper.c
@@ -46,6 +47,7 @@ override_dh_fixperms:
 	dh_fixperms
 	chmod u+s ${DC}/usr/lib/nagios/plugins/check_univention_joinstatus_suidwrapper
 	chmod u+s ${DC}/usr/lib/nagios/plugins/check_univention_ldap_suidwrapper
+	chmod u+s ${DC}/usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper
 	chmod u+s ${DC}/usr/lib/nagios/plugins/check_univention_winbind_suidwrapper
 	chmod u+s ${DC}/usr/lib/nagios/plugins/check_univention_nscd_suidwrapper
 	chmod u+s ${DC}/usr/lib/nagios/plugins/check_univention_slapd_mdb_maxsize_suidwrapper
@@ -56,6 +58,7 @@ override_dh_auto_clean:
 	rm -f debian/univention-nagios-client.conffiles
 	rm -f usr/lib/nagios/plugins/check_univention_joinstatus_suidwrapper
 	rm -f usr/lib/nagios/plugins/check_univention_ldap_suidwrapper
+	rm -f usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper
 	rm -f usr/lib/nagios/plugins/check_univention_winbind_suidwrapper
 	rm -f usr/lib/nagios/plugins/check_univention_nscd_suidwrapper
 	rm -f usr/lib/nagios/plugins/check_univention_slapd_mdb_maxsize_suidwrapper

--- a/nagios/univention-nagios/debian/univention-nagios-client.install
+++ b/nagios/univention-nagios/debian/univention-nagios-client.install
@@ -12,6 +12,8 @@ usr/lib/nagios/plugins/check_univention_joinstatus usr/lib/nagios/plugins/
 usr/lib/nagios/plugins/check_univention_joinstatus_suidwrapper usr/lib/nagios/plugins/
 usr/lib/nagios/plugins/check_univention_ldap usr/lib/nagios/plugins/
 usr/lib/nagios/plugins/check_univention_ldap_suidwrapper usr/lib/nagios/plugins/
+usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize usr/lib/nagios/plugins/
+usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper usr/lib/nagios/plugins/
 usr/lib/nagios/plugins/check_univention_smtp usr/lib/nagios/plugins/
 usr/lib/nagios/plugins/check_univention_nscd usr/lib/nagios/plugins/
 usr/lib/nagios/plugins/check_univention_nscd_suidwrapper usr/lib/nagios/plugins/

--- a/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize
+++ b/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Univention Nagios Plugin
+#  check listener's cache mdb maxsize
+#
+# Copyright 2007-2018 Univention GmbH
+# Copyright 2019 Adfinis SyGroup AG
+#
+# http://www.univention.de/
+#
+# All rights reserved.
+#
+# The source code of this program is made available
+# under the terms of the GNU Affero General Public License version 3
+# (GNU AGPL V3) as published by the Free Software Foundation.
+#
+# Binary versions of this program provided by Univention to you as
+# well as other copyrighted, protected or trademarked materials like
+# Logos, graphics, fonts, specific documentations and configurations,
+# cryptographic keys etc. are subject to a license agreement between
+# you and Univention and not subject to the GNU AGPL V3.
+#
+# In the case you use this program under the terms of the GNU AGPL V3,
+# the program is provided in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License with the Debian GNU/Linux or Univention distribution in file
+# /usr/share/common-licenses/AGPL-3; if not, see
+# <http://www.gnu.org/licenses/>.
+
+
+STATE_OK=0
+STATE_WARNING=1
+STATE_CRITICAL=2
+STATE_UNKNOWN=3
+
+nagios_exit() {
+	local state="$1"
+	local msg="$2"
+
+	case $state in
+	0)
+		echo "univention-directory-listener MDB OK: $msg"
+		exit 0
+		;;
+	1)
+		echo "univention-directory-listener MDB WARNING: $msg"
+		exit 1
+		;;
+	2)
+		echo "univention-directory-listener MDB CRITICAL: $msg"
+		exit 2
+		;;
+	*)
+		echo "univention-directory-listener MDB UNKNOWN: $msg"
+		exit 3
+		;;
+	esac
+}
+
+critical=90
+warn=75
+while test -n "$1"; do
+	case "$1" in
+		-w)
+			warn=$2
+			shift
+			;;
+		-c)
+			critical=$2
+			shift
+			;;
+	esac
+	shift
+done
+
+LC_ALL=C
+
+mdb_dir="/var/lib/univention-directory-listener/cache"
+mdb_file="$mdb_dir/data.mdb"
+if [ -e "$mdb_file" ]; then
+	test -x /usr/bin/mdb_stat || nagios_exit "$STATE_WARNING" "mdb_stat not found, please install lmdb-utils"
+	max_pages="$(mdb_stat -e $mdb_dir | sed -ne 's| *Max pages: ||p')"
+	used_pages="$(mdb_stat -e $mdb_dir | sed -ne 's| *Number of pages used: ||p')"
+	in_use=$(($used_pages*100/$max_pages))
+	if [ $in_use -ge $critical ]; then
+		nagios_exit $STATE_CRITICAL "More than $critical% (in fact $in_use%) of mdb database is use, please increase listener/cache/mdb/maxsize (and restart univention-directory-listener)"
+		echo "cri"
+	elif [ $in_use -ge $warn ]; then
+		nagios_exit "$STATE_WARNING" "More than $warn% (in fact $in_use%) of mdb database is use, consider increasing listener/cache/mdb/maxsize (and restart univention-directory-listener)"
+	else
+		nagios_exit $STATE_OK "System operational (in fact $in_use%)"
+	fi
+fi
+nagios_exit $STATE_OK "univention-directory-listener database file $mdb_file not found"

--- a/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper.c
+++ b/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper.c
@@ -1,0 +1,66 @@
+//
+// Univention Nagios Plugin
+//  wrapper to call script for checking listener_mdb_maxsize
+//
+// Copyright 2015-2018 Univention GmbH
+//
+// http://www.univention.de/
+//
+// All rights reserved.
+//
+// The source code of this program is made available
+// under the terms of the GNU Affero General Public License version 3
+// (GNU AGPL V3) as published by the Free Software Foundation.
+//
+// Binary versions of this program provided by Univention to you as
+// well as other copyrighted, protected or trademarked materials like
+// Logos, graphics, fonts, specific documentations and configurations,
+// cryptographic keys etc. are subject to a license agreement between
+// you and Univention and not subject to the GNU AGPL V3.
+//
+// In the case you use this program under the terms of the GNU AGPL V3,
+// the program is provided in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License with the Debian GNU/Linux or Univention distribution in file
+// /usr/share/common-licenses/AGPL-3; if not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <getopt.h>
+
+#define COMMAND "/usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize"
+
+main(int argc, char ** argv, char ** envp) {
+	int i = 0;
+	char warning[] = "75";
+	char critical[] = "90";
+	while ((i = getopt(argc, argv, "c:w:")) != -1) {
+		switch (i) {
+			case 'w':
+				strncpy(warning, optarg, 2);
+				break;
+			case 'c':
+				strncpy(critical, optarg, 2);
+				break;
+			default:
+				exit(EXIT_FAILURE);
+		}
+	}
+	uid_t uid = getuid();
+	if (setgid(getegid()))
+		perror("setgid");
+	if (setuid(geteuid()))
+		perror("setuid");
+	execle(COMMAND, COMMAND, "-w", warning, "-c", critical, (char *)0, (char *)0);
+	perror("execle");
+	setuid(uid);
+	exit(0);
+}

--- a/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_slapd_mdb_maxsize
+++ b/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_slapd_mdb_maxsize
@@ -31,7 +31,7 @@
 # <http://www.gnu.org/licenses/>.
 
 
-eval "$(ucr shell ldap/database/mdb/maxsize ldap/database/type)"
+eval "$(ucr shell ldap/database/type)"
 
 STATE_OK=0
 STATE_WARNING=1
@@ -87,14 +87,14 @@ if [ "$ldap_database_type" = "mdb" ]; then
 		test -x /usr/bin/mdb_stat || nagios_exit "$STATE_WARNING" "mdb_stat not found, please install lmdb-utils"
 		max_pages="$(mdb_stat -e $mdb_dir | sed -ne 's| *Max pages: ||p')"
 		used_pages="$(mdb_stat -e $mdb_dir | sed -ne 's| *Number of pages used: ||p')"
-		in_use=$(($used_pages*100/$max_pages))	
+		in_use=$(($used_pages*100/$max_pages))
 		if [ $in_use -ge $critical ]; then
 			nagios_exit $STATE_CRITICAL "More than $critical% (in fact $in_use%) of mdb database is use, please increase ldap/database/mdb/maxsize (and restart ldap server)"
 			echo "cri"
 		elif [ $in_use -ge $warn ]; then
 			nagios_exit "$STATE_WARNING" "More than $warn% (in fact $in_use%) of mdb database is use, consider increasing ldap/database/mdb/maxsize (and restart ldap server)"
 		else
-			nagios_exit $STATE_OK "System operational"
+			nagios_exit $STATE_OK "System operational (in fact $in_use%)"
 		fi
 	fi
 	nagios_exit $STATE_OK "Slapd database file $mdb_file not found"

--- a/nagios/univention-nagios/usr/share/nagios-plugins/templates-univention/univention.cfg
+++ b/nagios/univention-nagios/usr/share/nagios-plugins/templates-univention/univention.cfg
@@ -151,6 +151,12 @@ define command{
 	command_line	/usr/lib/nagios/plugins/check_univention_ldap_suidwrapper
 }
 
+# 'check_univention_listener_mdb_maxsize' command definition
+define command{
+	command_name check_univention_listener_mdb_maxsize
+	command_line /usr/lib/nagios/plugins/check_univention_listener_mdb_maxsize_suidwrapper -w $ARG1$ -c $ARG2$
+}
+
 # 'check_univention_smtp' command definition
 define command{
 	command_name    check_univention_smtp


### PR DESCRIPTION
## Please make sure you considered the following things

- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=48422

## Description of the changes

Add check to monitoring page use vs. maximum pages in MDB database file of the univention-directory-listener.

* **What kind of change does this PR introduce?** Feature, (minor) cleanup
* **How can we reproduce the issue?** Use the script to check mdb size of a directory listener
* **To which UCS version does the issue apply?** Tested on 4.3-3 Errata 390
* **Please list relevant screenshots, error messages, logs or tracebacks** (Added to the bugzilla issue)
* **Are there any breaking or API changes?** No.
* **Are there changes in the documentation necessary?** Possibly in the Nagios documentation.
* **Are there descriptions for newly introduced UCR variables?** No new UCR variables are introduced.
