### PR TITLE
Bug #48701: typo fixes in doc/scenarios

### DIFF
--- a/doc/scenarios/kanzlei-de.xml
+++ b/doc/scenarios/kanzlei-de.xml
@@ -32,8 +32,8 @@
   <section id="lawyer:services">
 	<title>Systeme und Dienste</title>
 	<para>
-	  Univention Corporate Server (UCS) stellt die benötigten Dienste und Anwendungen ``out of the
-	  box'' als Komplettlösung zur Verfügung. Es kommt ein einzelnes UCS-System zum Einsatz, das für
+	  Univention Corporate Server (UCS) stellt die benötigten Dienste und Anwendungen „out of the
+	  box“ als Komplettlösung zur Verfügung. Es kommt ein einzelnes UCS-System zum Einsatz, das für
 	  die Windows-Clients Anmelde- und Dateidienste bereitstellt, die Drucker verwaltet und das
 	  Backup der Daten automatisiert.
 	</para>
@@ -51,8 +51,8 @@
 	<para>
 	  Für die zehn Mitarbeiter werden im Web-Interface der &ucsUMC;
 	  Benutzerkonten angelegt. Jeder Mitarbeiter kann sich über die Benutzer
-      <emphasis>Self-Service</emphasis> App aus dem App Center sein Passwort selbst setzen, das -
-	  wie alle Benutzerdaten - in einem LDAP-Verzeichnisdienst gespeichert und
+      <emphasis>Self-Service</emphasis> App aus dem App Center sein Passwort selbst setzen, das –
+	  wie alle Benutzerdaten – in einem LDAP-Verzeichnisdienst gespeichert und
 	  bei der Anmeldung am Windows-Client abgefragt wird.
     </para>
 
@@ -69,13 +69,13 @@
 	<para>
 	  Auf dem UCS-System wird Samba 4 für die Anbindung der Windows-Clients eingesetzt. Samba 4
 	  bietet Domänen-, Verzeichnis- und Authentifizierungsdienste, die kompatibel zu Microsoft
-	  Active Directory sind. Diese ermöglichen auch die Verwendung der von Microsoft bereit
-	  gestellten Werkzeuge für die Verwaltung von Gruppenrichtlinien (GPOs).
+	  Active Directory sind. Diese ermöglichen auch die Verwendung der von Microsoft
+	  bereitgestellten Werkzeuge für die Verwaltung von Gruppenrichtlinien (GPOs).
 	</para>
 
 	<para>
-	  Windows-Clients können direkt der durch UCS bereitgestellten Active Directory-kompatiblen
-	  Domäne beitreten und können über Gruppenrichtlinien zentral konfiguriert werden. Der
+	  Windows-Clients können direkt der durch UCS bereitgestellten Active-Directory-kompatiblen
+	  Domäne beitreten und über Gruppenrichtlinien zentral konfiguriert werden. Der
 	  Domänen-Join ist aus Client-Sicht identisch mit dem Beitritt zu einer Windows-basierten
 	  Domäne.
 	</para>
@@ -91,7 +91,7 @@
 	</para>
 
 	<para>
-	  Darüberhinaus existiert ein zentrale Freigabe mit juristischer Fachliteratur im PDF-Format,
+	  Darüber hinaus existiert ein zentrale Freigabe mit juristischer Fachliteratur im PDF-Format,
 	  die auf jedem Client eingebunden wird.
 	</para>
 
@@ -104,10 +104,10 @@
 	<title>Single-Sign-On mit einer juristischen Fachanwendung</title>
 	<para>
 	  Die Kanzlei greift auf einen webbasierten juristischen Fachdienst zu. Dieser benutzt eine
-	  eigenständige Benutzerverwaltung. Um zu vermeiden das Benutzerkennungen und Passwörter doppelt
+	  eigenständige Benutzerverwaltung. Um zu vermeiden, dass Benutzerkennungen und Passwörter doppelt
 	  gepflegt werden müssen wird der UCS SAML Identity Provider eingebunden.
 	  SAML (Security Assertion Markup Language) ist ein XML-basierter Standard zum Austausch von
-	  Authentifizierungsinformationen, der u.a. Single-Sign-On über Domänengrenzen hinweg erlaubt.
+	  Authentifizierungsinformationen, der u. a. Single-Sign-On über Domänengrenzen hinweg erlaubt.
 	  Der juristische Fachdienst wird über ein kryptografisches Zertifikat fest registriert und
 	  vertraut dann dem UCS Identity Provider. Der Benutzer authentifiziert sich dann nur noch in
 	  UCS und kann den eingebundenen juristischen Dienst ohne erneute Authentifizierung nutzen.
@@ -124,10 +124,10 @@
 	  administriert werden. Die drei Drucker können bequem über die &ucsUMC; konfiguriert werden
 	  und stehen den Benutzern auf ihren Windows-Clients direkt zur Verfügung. Die beiden
 	  baugleichen Laserdrucker werden dabei zu einer Druckergruppe zusammengefasst: Das bedeutet,
-	  das die Benutzer neben der gezielten Auswahl eines Druckers auch die Möglichkeit erhalten,
-	  auf einen Pseudodrucker zu drucken. Die Druckaufträge werden dabei reihum um die beiden
+	  dass die Benutzer neben der gezielten Auswahl eines Druckers auch die Möglichkeit erhalten,
+	  auf einem Pseudodrucker zu drucken. Die Druckaufträge werden dabei reihum um die beiden
 	  Drucker der Druckergruppe verteilt. Bei belegten Druckern wird auf einen freien Drucker
-	  ausgewichen, so dass Wartezeiten vermieden werden.
+	  ausgewichen, sodass Wartezeiten vermieden werden.
 	</para>
   </section>
 
@@ -138,8 +138,8 @@
       Groupware mit Integration in UCS. Kopano greift dabei auf die
       Benutzerkontoinformationen des UCS-Verzeichnisdienstes zu. Die Verwaltung
       integriert sich nahtlos in die &ucsUMC;. Die Mitarbeiter verwenden die
-      webbasierte <emphasis>Kopano WebApp</emphasis>für ihren Kalender, auch als App im App Center
-      verfügbar.
+      webbasierte <emphasis>Kopano WebApp</emphasis> für ihren Kalender, die
+      auch als App im App Center verfügbar ist.
 	</para>
 
 	<para>
@@ -179,7 +179,7 @@
 	<para>
 	  Für den geplanten Zusammenschluss mit einem weiteren Büro in München kann einfach ein weiteres
 	  UCS-System in dieser Filliale installiert werden. Alle LDAP-Daten werden dann automatisch
-	  und verschlüsselt an den Standortserver übertragen, so dass Mitarbeiter sich bei
+	  und verschlüsselt an den Standortserver übertragen, sodass Mitarbeiter sich bei
 	  Vorort-Terminen am Münchner Standort mit ihren gewohnten Benutzerkennungen anmelden.
 	</para>
 

--- a/doc/scenarios/mittelstand-de.xml
+++ b/doc/scenarios/mittelstand-de.xml
@@ -15,7 +15,7 @@
 	<para>
 	  Ganupa Technologies ist einer der wichtigsten Hersteller für Walzstahlfräsen. Am Firmensitz in
 	  Deutschland arbeiten 260 Mitarbeiter in Produktion, Verwaltung, Konstruktion und
-	  Vertrieb. Außerdem gibt es in den USA, Argentinien und Indien lokale Standorte mit je 5-10
+	  Vertrieb. Außerdem gibt es in den USA, Argentinien und Indien lokale Standorte mit je 5–10
 	  Mitarbeitern.
 	</para>
 
@@ -27,7 +27,7 @@
 
 	<para>
 	  Für die Mitarbeiter aus der Verwaltung und dem Vertrieb soll nur eine Office-Suite, ein
-	  E-Mail-Client und ein Browser angeboten werden
+	  E-Mail-Client und ein Browser angeboten werden.
 	</para>
 
 	<para>
@@ -85,8 +85,8 @@
 	<para>
 	  Das Unternehmen implementiert eine Infrastruktur bestehend aus einem UCS Domänencontroller
 	  Master (DC Master), einem UCS Domänencontroller Backup (DC Backup), mehreren UCS
-      Domänencontroller Slave (DC Slave) und Arbeitsplatzsysteme für
-      Mitarbeiter bestehend aus Desktop Computern und Notebooks. Zum Einsatz
+      Domänencontroller Slave (DC Slave) und Arbeitsplatzsystemen für
+      Mitarbeiter bestehend aus Desktop-Computern und Notebooks. Zum Einsatz
       kommen Microsoft Windows und Ubuntu Linux.
 	</para>
 
@@ -118,14 +118,14 @@
 	<title>Virtualisierung</title>
 	<para>
 	  Alle Serversysteme in der Umgebung von Ganupa Technologies sind mit &ucsUVMM; (UVMM)
-	  virtualisiert. Zum Einsatz kommt dabei ausschliesslich Open Source-Software.
+	  virtualisiert. Zum Einsatz kommt dabei ausschliesslich Open-Source-Software.
 	</para>
 
 	<para>
 	  Als Grundlage der Virtualisierung dienen Virtualisierungsserver auf Memberservern
 	  (UCS-Serversysteme ohne lokalen LDAP-Server). Auf diesen laufen jeweils ein bis mehrere
 	  virtuelle Maschinen mit der Virtualisierungslösung KVM. UCS- und Windows-Systeme werden
-	  paravirtualisiert betrieben, d.h. durch einen Zugriff der virtualisierten Systeme auf die
+	  paravirtualisiert betrieben, d. h. durch einen Zugriff der virtualisierten Systeme auf die
 	  Ressourcen der Wirtsysteme kann ein höherer Durchsatz erzielt werden.
 	  Paravirtualisierungstreiber für KVM werden von Univention als signierte
 	  MSI-Installationspakete bereitgestellt und können so einfach installiert werden.
@@ -160,8 +160,8 @@
 
 	<para>
 	  In einigen Großraumbüros sind mehrere Drucker zu einer Druckergruppe zusammengefasst; die
-	  Benutzer drucken einfach auf diese Gruppe, wobei die Druckaufträge gleichmässig verteilt
-	  werden und der nächste freie Drucker verwendet wird. Die Benutzer müssen so nicht prüfen ob
+	  Benutzer drucken einfach auf diese Gruppe, wobei die Druckaufträge gleichmäßig verteilt
+	  werden und der nächste freie Drucker verwendet wird. Die Benutzer müssen so nicht prüfen, ob
 	  ein Drucker gerade in Verwendung ist.
 	</para>
 
@@ -175,12 +175,12 @@
   </section>
 
   <section id="engineering:db">
-	<title>Einbindung von Oracle Solaris-Systemen</title>
+	<title>Einbindung von Oracle-Solaris-Systemen</title>
 	<para>
 	  Eine Fachanwendung für CAD-Konstruktionen ist nur für Oracle Solaris verfügbar. Die
 	  Namensdienste auf dem Solaris-System wurden auf eine Authentifizierung gegen das UCS-LDAP
-	  angepasst, d.h. Benutzer können sich auf dem Solaris-System mit ihrer Domänen-Benutzerkennung
-	  und -Passwort anmelden. Die zusätzliche Pflege lokaler Benutzerkonten auf dem Solaris-System
+	  angepasst, d. h. Benutzer können sich auf dem Solaris-System mit ihrer Domänen-Benutzerkennung
+	  und ihrem Domänen-Passwort anmelden. Die zusätzliche Pflege lokaler Benutzerkonten auf dem Solaris-System
 	  entfällt so.
 	</para>
 
@@ -214,13 +214,13 @@
 	</para>
 
 	<para>
-	  Die Verwaltung der Groupware-relavanten Attribute integriert sich nahtlos in die &ucsUMC;. Die
+	  Die Verwaltung der Groupware-relevanten Attribute integriert sich nahtlos in die &ucsUMC;. Die
 	  Mitarbeiter greifen auf die Groupware über den Open-Xchange App Suite Web-Client und Mozilla Thunderbird
 	  zu.
 	</para>
 
 	<para>
-	  Mobile Endgeräte (Smartphones und Tablets) werden über das Microsoft ActiveSync-Protokoll
+	  Mobile Endgeräte (Smartphones und Tablets) werden über das Microsoft-ActiveSync-Protokoll
 	  integriert.
 	</para>
 

--- a/doc/scenarios/versicherung-de.xml
+++ b/doc/scenarios/versicherung-de.xml
@@ -26,7 +26,7 @@
 
 	<para>
 	  Die Mitarbeiter arbeiten an insgesamt 36 Standorten weltweit, der
-	  grösste davon der Stammsitz in Bremen mit ca. 250 Personen. Viele der
+	  größte davon der Stammsitz in Bremen mit ca. 250 Personen. Viele der
 	  Benutzer arbeiten als Vertreter oder Gutachter mobil mit Notebooks.
 	</para>
 
@@ -56,7 +56,7 @@
 	<para>
 	  Alle Serversysteme in der Zentrale sollen virtualisiert
 	  werden. Aufgrund der daraus erwachsenden erheblichen Bedeutung der
-	  Virtualisierung muss dafür eine Open Source-Lösung zum Einsatz kommen.
+	  Virtualisierung muss dafür eine Open-Source-Lösung zum Einsatz kommen.
 	</para>
 
 	<para>
@@ -126,8 +126,7 @@
 	<title>Virtualisierung</title>
 	<para>
 	  Alle Serversysteme in der Umgebung der HMV sind mit &ucsUVMM; (UVMM)
-	  virtualisiert. Zum Einsatz kommt dabei ausschliesslich Open
-	  Source-Software.
+	  virtualisiert. Zum Einsatz kommt dabei ausschließlich Open-Source-Software.
 	</para>
 
 	<para>
@@ -142,7 +141,7 @@
 	  Virtualisierungsserver auf UCS-Memberservern (Serversysteme
 	  ohne lokalen Verzeichnisdienst). Auf diesen laufen jeweils ein bis mehrere
 	  virtuelle Maschinen mit der Virtualisierungslösung KVM. UCS- und
-	  Windows-Systeme werden paravirtualisiert betrieben, d.h. durch einen
+	  Windows-Systeme werden paravirtualisiert betrieben, d. h. durch einen
 	  Zugriff der virtualisierten Systeme auf die Ressourcen der Wirtsysteme
 	  kann ein höherer Durchsatz erzielt werden.
 	</para>
@@ -182,7 +181,7 @@
 
 	<para>
 	  Alle Systeme tragen die installierten Pakete automatisch in eine
-	  zentrale SQL-Datenbank ein, so dass ein Überblick über den
+	  zentrale SQL-Datenbank ein, sodass ein Überblick über den
 	  Softwarebestand stets gewährleistet ist. Sicherheitsupdates für UCS
 	  werden zeitnah zum Download bereitgestellt und können ebenfalls
 	  automatisiert eingespielt werden.
@@ -196,7 +195,7 @@
 	  eingesetzt. Samba 4 bietet Domänen-, Verzeichnis- und
 	  Authentifizierungsdienste, die kompatibel zu Microsoft Active
 	  Directory sind. Diese ermöglichen auch die Verwendung der von
-	  Microsoft bereit gestellten Werkzeuge für die Verwaltung von
+	  Microsoft bereitgestellten Werkzeuge für die Verwaltung von
 	  Gruppenrichtlinien (GPOs).
 	</para>
 
@@ -259,7 +258,7 @@
 	</para>
 
 	<para>
-	  Durch die Anbindung des UCS-Verzeichnisdienstes and das Active
+	  Durch die Anbindung des UCS-Verzeichnisdienstes an das Active
 	  Directory der Konzernmutter erfolgt die Authentifizierung mit der
 	  gleichen Benutzernamen/Passwort-Kombination.
 	</para>
@@ -322,7 +321,7 @@
 	</para>
 
 	<para>
-	  Nagios-Prüfungen können zeitlich eingeschränkt werden, so dass
+	  Nagios-Prüfungen können zeitlich eingeschränkt werden, sodass
 	  unkritische Werte beispielsweise nachts keine Meldungen auslösen.
 	</para>
   </section>
@@ -330,7 +329,7 @@
   <section id="insurance:aix">
 	<title>Integration des AIX-Systems</title>
 	<para>
-	  Die Versichungspolicen werden mit einer Applikation verwaltet, die nur
+	  Die Versicherungspolicen werden mit einer Applikation verwaltet, die nur
 	  auf hochverfügbaren POWER7-Systemen mit IBM AIX betrieben werden kann.
 	</para>
 

--- a/doc/scenarios/versicherung-de.xml
+++ b/doc/scenarios/versicherung-de.xml
@@ -360,7 +360,7 @@
       verschiedenen Backup-Agenten, die sowohl komplette Systeme als auch Daten
       sichern können. Für die Sicherung von Datenbanken stehen etwa gesonderte
       Agenten zur Verfügung. Alle Daten werden von den Standort-Servern in die
-      Zentrale kopiert und dort auf
+      Zentrale kopiert und dort auf einem Streamer gesichert.
 	</para>
   </section>
 


### PR DESCRIPTION
## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=48701

## Description of the changes

This fixes several typos and grammar/spelling/punctuation flaws in `doc/scenarios/*-de.xml` and completes the missing sentence part in `doc/scenarios/versicherung-de.xml` (line 363–364):

> Alle Daten werden von den Standort-Servern in die Zentrale kopiert und dort auf **einem Streamer gesichert.**