### PR TITLE
Feature: Make AD connector synchronization of userPrincipalName configurable

### DIFF
--- a/services/univention-ad-connector/debian/univention-ad-connector.univention-config-registry-variables
+++ b/services/univention-ad-connector/debian/univention-ad-connector.univention-config-registry-variables
@@ -261,3 +261,9 @@ Description[de]=Synchronisiere den UCS Benutzername auf den AD User Principal Na
 Description[en]=Synchronize the UCS user name to the AD User Principal Name (default is True).
 Type=bool
 Categories=service-adcon
+
+[con.*/ad/mapping/user/userPrincipalNameAttribute]
+Description[de]=Synchronisiere ein bestimmtes Attribut aus UCS auf den AD User Principal Name. Das Attribut muss single-valed und konform mit RFC822 sein. mapping/sync/userPrincipalName muss ebenfalls aktiviert sein. (default ist leer, ist ).
+Description[en]=Synchronize a specific attribute from UCS to the AD User Principal Name. The attribute has to be single-valued and single-valued. mapping/sync/userPrincipalName has to be enabled too. (default is empty).
+Type=bool
+Categories=service-adcon


### PR DESCRIPTION
Thank you for providing a pull request!

## Please make sure you considered the following things

- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=49954 (updated, initially pasted the URL for another issue)

## Description of the changes

This is a proposal for making the mapping userPrincipalName configurable details are

* **What kind of change does this PR introduce?** Feature
* **How can we reproduce the issue?** 
  * Have a UCS domain controller with AD connector configure for synchronization with a Windows Server AD (in my case Server 2012 R2, english, patched)
  * Put AD connector in write mode: ucr set connector/ad/mapping/syncmode='write' (For the sake of having comparable environments)
  * Apply the patch to __init__.py
  * Define the mapping attribute, i.e. mailPrimaryAddress: ucr set ad/mapping/user/userPrincipalNameAttribute='mailPrimaryAddress'
  * Enable highest debug level of the connector to see changes in the log: ucr set connector/debug/level='4'
  * Restart the univention AD connector: systemctl restart univention-ad-connector
  * Modify the mailprimaryAddress of a user via UDM Web or CLI
  * UPN should be updated in AD and the log output of the AD connector should contain mailPrimaryAddress instead of uid@kerberosrealm

* **To which UCS version does the issue apply?** 4.4-1 and before.
* **Please list relevant screenshots, error messages, logs or tracebacks** n/a yet
* **Are there any breaking or API changes?** The code was modified so that it shouldn't change default behaviour. However if a person purposely maps an attribute that is not single-valued or RFC 822 compliant, there are errors to be expected as that are AD's requirement for userPrincipalName.
* **Are there changes in the documentation necessary?** The variable should be mentioned in a changelog if the MR is accepted.
* **Are there descriptions for newly introduced UCR variables?** Yes, however the definitive variable name can be discussed :-)

Looking forward to hearing from you