### PR TITLE
WiP slapd: Reduce diff between Debian init script, eventually fix #18500

### DIFF
--- a/management/univention-ldap/conffiles/etc/default/slapd
+++ b/management/univention-ldap/conffiles/etc/default/slapd
@@ -1,0 +1,53 @@
+@%@UCRWARNING=# @%@
+# Default location of the slapd.conf file or slapd.d cn=config directory. If
+# empty, use the compiled-in default (/etc/ldap/slapd.d with a fallback to
+# /etc/ldap/slapd.conf).
+SLAPD_CONF=
+
+# System account to run the slapd server under. If empty the server
+# will run as root.
+SLAPD_USER="openldap"
+
+# System group to run the slapd server under. If empty the server will
+# run in the primary group of its user.
+SLAPD_GROUP="openldap"
+
+# Path to the pid file of the slapd server. If not set the init.d script
+# will try to figure it out from $SLAPD_CONF (/etc/ldap/slapd.conf by
+# default)
+SLAPD_PIDFILE=
+
+# slapd normally serves ldap only on all TCP-ports 389. slapd can also
+# service requests on TCP-port 636 (ldaps) and requests via unix
+# sockets.
+# Example usage:
+# SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
+#SLAPD_SERVICES="ldap:/// ldapi:///"
+@!@
+SLAPD_SERVICES=['ldapi:///']
+for p in configRegistry.get('slapd/port', '7389').split(','):
+	SLAPD_SERVICES.append('ldap://:%s/' % p)
+for p in configRegistry.get('slapd/port/ldaps', '7636').split(','):
+	SLAPD_SERVICES.append('ldaps://:%s/' % p)
+print 'SLAPD_SERVICES="%s"' % ' '.join(SLAPD_SERVICES)
+@!@
+# If SLAPD_NO_START is set, the init script will not start or restart
+# slapd (but stop will still work).  Uncomment this if you are
+# starting slapd via some other means or if you don't want slapd normally
+# started at boot.
+#SLAPD_NO_START=1
+
+# If SLAPD_SENTINEL_FILE is set to path to a file and that file exists,
+# the init script will not start or restart slapd (but stop will still
+# work).  Use this for temporarily disabling startup of slapd (when doing
+# maintenance, for example, or through a configuration management system)
+# when you don't want to edit a configuration file.
+SLAPD_SENTINEL_FILE=/etc/ldap/noslapd
+
+# For Kerberos authentication (via SASL), slapd by default uses the system
+# keytab file (/etc/krb5.keytab).  To use a different keytab file,
+# uncomment this line and change the path.
+#export KRB5_KTNAME=/etc/krb5.keytab
+
+# Additional options to pass to slapd
+SLAPD_OPTIONS=""

--- a/management/univention-ldap/conffiles/etc/init.d/slapd
+++ b/management/univention-ldap/conffiles/etc/init.d/slapd
@@ -1,332 +1,202 @@
 #!/bin/sh
-@%@UCRWARNING=# @%@
-# pidfile: /var/run/slapd/slapd.pid
 ### BEGIN INIT INFO
-# Provides:			 slapd
-# Required-Start:	 $remote_fs $network $syslog
-# Required-Stop:	 $remote_fs $network $syslog
-# Default-Start:	 2 3 4 5
-# Default-Stop:		 0 1 6
+# Provides:          slapd
+# Required-Start:    $remote_fs $network $syslog
+# Required-Stop:     $remote_fs $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
 # Short-Description: OpenLDAP standalone server (Lightweight Directory Access Protocol)
 ### END INIT INFO
-#
-# Written by Miquel van Smoorenburg <miquels@drinkel.ow.org>.
-# Modified for Debian GNU/Linux by Ian Murdock <imurdock@gnu.ai.mit.edu>.
-# Modified for Debian by Christoph Lameter <clameter@debian.org>
-# Modified for OpenLDAP by Ben Collins <bcollins@debian.org>
-# Modified for UCS by Univention <packages@univention.de>
 
-
-PATH=/bin:/usr/bin:/sbin:/usr/sbin
-DAEMON=/usr/sbin/slapd
-SLAPDCONF=/etc/ldap/slapd.conf
+# Specify path variable
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
 
 . /lib/lsb/init-functions
 
-exit_if_start_is_running ()
-{
-	local pid
-	pid=$(pgrep -cf "^/bin/sh /etc/init.d/slapd start$")
-	if [ -n "$pid" ] && [ "$pid" -gt 1 ]; then
-		log_action_msg "WARNING: Another /etc/init.d/slapd start is already in progress."
-		exit 1
-	fi
-}
+# Kill me on all errors
+set -e
 
-bdbrecover ()
-{
-	local back_bdb_version
-	local DBRECOVER
-	local DBSTAT
-	local dbstat_output
-	local dbstat_rc
-	local bdb_version
-	local stale_locks
-	local logger_tag
-	local line
+# Set the paths to slapd as a variable so that someone who really
+# wants to can override the path in /etc/default/slapd.
+SLAPD=/usr/sbin/slapd
 
-	log_action_begin_msg "Check database: "
-	# determine libdb version that back-bdb.so was linked against
-	back_bdb_version="$(/usr/bin/ldd /usr/lib/ldap/back_bdb.so | sed -n 's|.*/usr/lib/.*/libdb-\([0-9.]*\).so.*|\1|p')"
-	DBRECOVER="/usr/bin/db${back_bdb_version}_recover"
-	DBSTAT="/usr/bin/db${back_bdb_version}_stat"
-	if [ -e "${DBRECOVER}" ]; then
-		# check if the db_stat version works on the database environment
-		dbstat_output=$("${DBSTAT}" -h /var/lib/univention-ldap/ldap -Ne 2>&1)
-		dbstat_rc=$?
-		if [ "$dbstat_rc" = 0 ]; then
-			bdb_version=$(echo "$dbstat_output" | sed -rn 's/^([^\s]+)\s+Environment version$/\1/p')
-			if [ -n "$bdb_version" ]; then
-				# check for stale locks or stale futexes
-				stale_locks=$("${DBSTAT}" -h /var/lib/univention-ldap/ldap -Nc 2>&1 | sed -rn 's/([0-9]*)\t*Number of current locks/\1/p')
-				if [ "$stale_locks" != 0 ]; then
-					exit_if_start_is_running
-					log_action_msg "WARNING"
-					log_action_msg "WARNING: There are $stale_locks stale locks in LDAP backend Berkeley DB (version $bdb_version)"
-					log_action_msg "WARNING: If slapd does not respond, manual LDAP dump/restore may be necessary"
-					log_action_begin_msg "Continuing BDB database check: "
-				fi
-				logger_tag="slapd db${back_bdb_version}_recover"
-				dbrecover_output=$("${DBRECOVER}" -h /var/lib/univention-ldap/ldap -e 2>&1)
-				if [ "$?" != 0 ]; then
-					exit_if_start_is_running
-				else
-					echo "$dbrecover_output" | while read line; do logger -t "$logger_tag" "$line"; done
-				fi
-				log_action_end_msg 0
-			else
-				log_action_msg "/var/lib/univention-ldap/ldap BDB Version does not seem to match the one back-bdb uses"
-				log_action_msg "Skipping ${DBRECOVER} to avoid damage"
+# Stop processing if slapd is not there
+[ -x $SLAPD ] || exit 0
 
-				logger_tag="slapd db${back_bdb_version}_stat"
-				logger -t "$logger_tag" "BDB file version detection failed:"
-				echo "$dbstat_output" | while read line; do logger -t "$logger_tag" "$line"; done
-			fi
-		else
-			log_action_msg "Could not determine BDB version of /var/lib/univention-ldap/ldap"
-			exit_if_start_is_running
-			log_action_msg "Skipping ${DBRECOVER} to avoid damage"
+# debconf may have this file descriptor open and it makes things work a bit
+# more reliably if we redirect it as a matter of course.  db_stop will take
+# care of this, but this won't hurt.
+exec 3>/dev/null
 
-			logger_tag="slapd db${back_bdb_version}_stat"
-			logger -t "$logger_tag" "command failed ($dbstat_rc):"
-			echo "$dbstat_output" | while read line; do logger -t "$logger_tag" "$line"; done
-		fi
-	else
-		log_action_msg "back-bdb was linked against ${back_bdb_version}, but db${back_bdb_version}-util package does not seem to be installed"
-		log_action_msg "Skipping ${DBRECOVER}"
-	fi
-}
-
-check_subschema ()
-{
-	tmpfile=`mktemp`
-	res=1
-	count=0
-	while [ $res != 0 ] ; do
-		ldapsearch -x -H ldapi:/// -s base -b cn=Subschema 'objectClass=subschema' objectClasses attributeTypes matchingRules matchingRuleUse dITStructureRules dITContentRules nameForms ldapSyntaxes >$tmpfile
-		res=$?
-		if [ $res != 0 ]; then
-			count=$((count+1))
-			if [ $count -ge 5 ]; then
-				echo "Failed to search schema"
-				exit 1
-			fi
-			sleep 2
-		fi
-	done
-@!@
-if configRegistry.is_true('ldap/schema/export'):
-		print '\tcp $tmpfile /var/www/ldap-schema.txt'
-		print '\tchmod a+r /var/www/ldap-schema.txt'
-@!@
-	md5=`md5sum $tmpfile | awk '{print $1}'`
-	rm -f "$tmpfile"
-
-	if [ ! -d /var/lib/univention-ldap/schema ]; then
-		mkdir /var/lib/univention-ldap/schema
-	fi
-	if [ ! -e /var/lib/univention-ldap/schema/md5 ]; then
-		touch /var/lib/univention-ldap/schema/md5
-	fi
-	md5_old=`cat /var/lib/univention-ldap/schema/md5`
-	if [ "$md5" != "$md5_old" ]; then
-		if [ ! -d /var/lib/univention-ldap/schema/id ]; then
-			mkdir /var/lib/univention-ldap/schema/id
-		fi
-		if [ ! -e /var/lib/univention-ldap/schema/id/id ]; then
-			touch /var/lib/univention-ldap/schema/id/id
-		fi
-		id=`cat /var/lib/univention-ldap/schema/id/id`
-		if [ -z "$id" ]; then
-			id=0
-		fi
-		id=$((id+1))
-		echo "$md5" >/var/lib/univention-ldap/schema/md5
-		echo "$id" >/var/lib/univention-ldap/schema/id/id
-		chown listener /var/lib/univention-ldap/schema/id/id
-	else
-		id=`cat /var/lib/univention-ldap/schema/id/id`
-		if [ -z "$id" ]; then
-			echo "1" >/var/lib/univention-ldap/schema/id/id
-			chown listener /var/lib/univention-ldap/schema/id/id
-		fi
-	fi
-}
-
-check_replog_file ()
-{
-	test -f /var/lib/univention-ldap/replog/replog || \
-		touch /var/lib/univention-ldap/replog/replog
-	chmod 0600 /var/lib/univention-ldap/replog/replog
-	test -f /var/lib/univention-ldap/replog/replog.lock || \
-		touch /var/lib/univention-ldap/replog/replog.lock
-}
-
-
-if [ -f "$SLAPDCONF" ]; then
-	pidfile=`grep ^pidfile $SLAPDCONF | awk '{print $2}'`
-	if [ -z "$pidfile" ]; then
-		pidfile="/var/run/slapd/slapd.pid"
-	fi
-	pidfiledir="$(dirname $pidfile)"
-	test ! -e "$pidfiledir" && mkdir -p "$pidfiledir"
-else
-	exit 0
+# Source the init script configuration
+if [ -f "/etc/default/slapd" ]; then
+	. /etc/default/slapd
 fi
 
-test -f $DAEMON || exit 0
+# Load the default location of the slapd config file
+if [ -z "$SLAPD_CONF" ]; then
+	if [ -e /etc/ldap/slapd.d ]; then
+		SLAPD_CONF=/etc/ldap/slapd.d
+	else
+		SLAPD_CONF=/etc/ldap/slapd.conf
+	fi
+fi
+
+# Stop processing if the config file is not there
+if [ ! -r "$SLAPD_CONF" ]; then
+  log_warning_msg "No configuration file was found for slapd at $SLAPD_CONF."
+  # if there is no config at all, we should assume slapd is not running
+  # and exit 0 on stop so that unconfigured packages can be removed.
+  [ "x$1" = xstop ] && exit 0 || exit 1
+fi
+
+# extend options depending on config type
+if [ -f "$SLAPD_CONF" ]; then
+	SLAPD_OPTIONS="-f $SLAPD_CONF $SLAPD_OPTIONS"
+elif [ -d "$SLAPD_CONF" ] ; then
+	SLAPD_OPTIONS="-F $SLAPD_CONF $SLAPD_OPTIONS"
+fi
+
+# Find out the name of slapd's pid file
+if [ -z "$SLAPD_PIDFILE" ]; then
+	# If using old one-file configuration scheme
+	if [ -f "$SLAPD_CONF" ] ; then
+		SLAPD_PIDFILE=`sed -ne 's/^pidfile[[:space:]]\+\(.\+\)/\1/p' \
+			"$SLAPD_CONF"`
+	# Else, if using new directory configuration scheme
+	elif [ -d "$SLAPD_CONF" ] ; then
+		SLAPD_PIDFILE=`sed -ne \
+			's/^olcPidFile:[[:space:]]\+\(.\+\)[[:space:]]*/\1/p' \
+			"$SLAPD_CONF"/'cn=config.ldif'`
+	fi
+fi
+
+# XXX: Breaks upgrading if there is no pidfile (invoke-rc.d stop will fail)
+# -- Torsten
+if [ -z "$SLAPD_PIDFILE" ]; then
+	log_failure_msg "The pidfile for slapd has not been specified"
+	exit 1
+fi
+
+# Pass the user and group to run under to slapd
+if [ "$SLAPD_USER" ]; then
+	SLAPD_OPTIONS="-u $SLAPD_USER $SLAPD_OPTIONS"
+fi
+
+if [ "$SLAPD_GROUP" ]; then
+	SLAPD_OPTIONS="-g $SLAPD_GROUP $SLAPD_OPTIONS"
+fi
+
+# Check whether we were configured to not start the services.
+check_for_no_start() {
+	if [ -n "$SLAPD_NO_START" ]; then
+		echo 'Not starting slapd: SLAPD_NO_START set in /etc/default/slapd' >&2
+		exit 0
+	fi
+	if [ -n "$SLAPD_SENTINEL_FILE" ] && [ -e "$SLAPD_SENTINEL_FILE" ]; then
+		echo "Not starting slapd: $SLAPD_SENTINEL_FILE exists" >&2
+		exit 0
+	fi
+}
+
+# Tell the user that something went wrong and give some hints for
+# resolving the problem.
+report_failure() {
+	log_end_msg 1
+	if [ -n "$reason" ]; then
+		log_failure_msg "$reason"
+	else
+		log_failure_msg "The operation failed but no output was produced."
+
+		if [ -n "$SLAPD_OPTIONS" -o \
+		     -n "$SLAPD_SERVICES" ]; then
+			if [ -z "$SLAPD_SERVICES" ]; then
+				if [ -n "$SLAPD_OPTIONS" ]; then
+					log_failure_msg "Command line used: slapd $SLAPD_OPTIONS"
+				fi
+			else
+				log_failure_msg "Command line used: slapd -h '$SLAPD_SERVICES' $SLAPD_OPTIONS"
+			fi
+		fi
+	fi
+}
+
+# Start the slapd daemon and capture the error message if any to 
+# $reason.
+start_slapd() {
+	# Make sure /var/run/slapd exists with correct permissions
+	if [ ! -d /var/run/slapd ]; then
+		mkdir -p /var/run/slapd
+		[ -z "$SLAPD_USER" ] || chown -R "$SLAPD_USER" /var/run/slapd
+		[ -z "$SLAPD_GROUP" ] || chgrp -R "$SLAPD_GROUP" /var/run/slapd
+	fi
+
+	# Make sure the pidfile directory exists with correct permissions
+	piddir=`dirname "$SLAPD_PIDFILE"`
+	if [ ! -d "$piddir" ]; then
+		mkdir -p "$piddir"
+		[ -z "$SLAPD_USER" ] || chown -R "$SLAPD_USER" "$piddir"
+		[ -z "$SLAPD_GROUP" ] || chgrp -R "$SLAPD_GROUP" "$piddir"
+	fi
+
+	if [ -z "$SLAPD_SERVICES" ]; then
+		reason="`start-stop-daemon --start --quiet --oknodo \
+			--pidfile "$SLAPD_PIDFILE" \
+			--exec $SLAPD -- $SLAPD_OPTIONS 2>&1`"
+	else
+		reason="`start-stop-daemon --start --quiet --oknodo \
+			--pidfile "$SLAPD_PIDFILE" \
+			--exec $SLAPD -- -h "$SLAPD_SERVICES" $SLAPD_OPTIONS 2>&1`"
+	fi
+
+	# Backward compatibility with OpenLDAP 2.1 client libraries.
+	if [ ! -h /var/run/ldapi ] && [ ! -e /var/run/ldapi ] ; then
+		ln -s slapd/ldapi /var/run/ldapi
+	fi
+}
+
+# Stop the slapd daemon and capture the error message (if any) to
+# $reason.
+stop_slapd() {
+	reason="`start-stop-daemon --stop --quiet --oknodo --retry TERM/10 \
+		--pidfile "$SLAPD_PIDFILE" \
+		--exec $SLAPD 2>&1`"
+}
+
+# Start the OpenLDAP daemons
+start_ldap() {
+	trap 'report_failure' 0
+	log_daemon_msg "Starting OpenLDAP" "slapd"
+	start_slapd
+	trap "-" 0
+	log_end_msg 0
+}
+
+# Stop the OpenLDAP daemons
+stop_ldap() {
+	trap 'report_failure' 0
+	log_daemon_msg "Stopping OpenLDAP" "slapd"
+	stop_slapd
+	trap "-" 0
+	log_end_msg 0
+}
 
 case "$1" in
   start)
-	# check ucr autostart setting
-	if [ -f "/usr/share/univention-config-registry/init-autostart.lib" ]; then
-		. "/usr/share/univention-config-registry/init-autostart.lib"
-		check_autostart ldap ldap/autostart
-	fi
-	# check that no slapd is running
-	if ! start-stop-daemon --start --quiet --exec $DAEMON --test > /dev/null; then
-		log_action_msg "LDAP server already running"
-		exit 0
-	fi
-	logger "/etc/init.d/slapd $1 (pid: $$, ppid:$(ps -p $PPID -o pid= -o comm=))"
-@!@
-if configRegistry['ldap/database/type'] == 'bdb':
-	print '\t# check backend database'
-	print '\tbdbrecover'
-if configRegistry.get('ldap/replog', '').lower() in ('true', 'yes'):
-	print '\tcheck_replog_file'
-@!@
-
-	log_action_begin_msg "Starting ldap server(s): slapd "
-
-@!@
-uris=['ldapi:///']
-for p in configRegistry.get('slapd/port', '7389').split(','):
-	uris.append('ldap://:%s/' % p)
-for p in configRegistry.get('slapd/port/ldaps', '7636').split(','):
-	uris.append('ldaps://:%s/' % p)
-print '\turis="%s"' % ' '.join(uris)
-if configRegistry.get('ldap/maxopenfiles'):
-	print '\t\tulimit -n %s' % configRegistry['ldap/maxopenfiles']
-@!@		start-stop-daemon --start --quiet \
-			--exec $DAEMON -- -h "${uris}"
-	rvalue=$?
-	fail_msg=""
-	# Bug #33993
-	if [ "i686" = "$(uname -m)" ]; then
-		for i in $(seq 1 3); do
-			[ $rvalue -eq 0 ] && break
-			sleep 1
-			start-stop-daemon --start --quiet --exec $DAEMON -- -h "${uris}"
-			rvalue=$?
-		done
-		[ $rvalue -ne 0 ] && fail_msg="slapd start failed, check if ldap/database/mdb/maxsize is supported on this architecture"
-	fi
-	log_action_end_msg $rvalue "$fail_msg"
-	if [ $rvalue != 0 ]; then
-		exit_if_start_is_running
-		[ -e /usr/sbin/slapschema ] && log_action_msg $(/usr/sbin/slapschema 2>&1)
-		exit $rvalue
-	fi
-
-	test -e /var/run/slapd/ldapi && ln -sf /var/run/slapd/ldapi /var/run/ldapi
-
-@!@
-if configRegistry['ldap/server/type']=="master":
-	print '\tlog_action_begin_msg "Checking Schema ID: "'
-	print '\tcheck_subschema 2>&1'
-	print '\tlog_action_end_msg 0'
-@!@
-
-	if [ -e /var/lib/univention-directory-replication/failed.ldif ]; then
-		log_action_begin_msg "Found failed.ldif. Importing "
-		test -x /usr/sbin/univention-directory-replication-resync && /usr/sbin/univention-directory-replication-resync /var/lib/univention-directory-replication/failed.ldif >>/var/log/univention/listener.log 2>&1
-		if [ $? = 0 ]; then
-			log_action_end_msg 0
-		else
-			log_action_end_msg 1
-			log_action_msg "Please check /var/log/univention/listener.log"
-			exit 1
-		fi
-	fi
-
-	;;
+	check_for_no_start
+  	start_ldap ;;
   stop)
-	logger "/etc/init.d/slapd $1 (pid: $$, ppid:$(ps -p $PPID -o pid= -o comm=))"
-	log_action_begin_msg "Stopping ldap server(s): slapd "
-	## first try with pidfile
-	start-stop-daemon --stop --quiet --oknodo --retry 10 \
-		--pidfile "$pidfile" -v | sed -rn 's/.*, (retry #|refused to die)/\1/p' \
-		| while read line; do log_action_cont_msg "$line"; done
-	## check process (instead of [ $? -eq 2 ])
-	pid=$(pgrep -f "^$DAEMON")
-	if [ -n "$pid" ]; then
-		log_action_end_msg 1
-		## try via executable name
-		log_action_begin_msg "Slapd still running ($pid), terminating via executable name"
-		start-stop-daemon --stop --quiet --oknodo --retry 10 \
-			--exec $DAEMON -v | sed -rn 's/.*, (retry #|refused to die)/\1/p' \
-			| while read line; do log_action_cont_msg "$line"; done
-		rm -f "$pidfile"
-	fi
-	log_action_end_msg 0
-	;;
+  	stop_ldap ;;
   restart|force-reload)
-	logger "/etc/init.d/slapd $1 (pid: $$, ppid:$(ps -p $PPID -o pid= -o comm=))"
-	log_action_msg "Restarting ldap server(s)"
-	$0 stop
-	$0 start
+	check_for_no_start
+  	stop_ldap
+	start_ldap
 	;;
-  force-stop)
-	logger "/etc/init.d/slapd $1 (pid: $$, ppid:$(ps -p $PPID -o pid= -o comm=))"
-	log_action_begin_msg "Stopping ldap servers (forced) "
-	start-stop-daemon --stop --quiet --oknodo --retry forever/KILL \
-		--exec $DAEMON
-	rm -f "$pidfile"
-	log_action_end_msg 0
-	;;
-  crestart)
-	logger "/etc/init.d/slapd $1 (pid: $$, ppid:$(ps -p $PPID -o pid= -o comm=))"
-	if pidof slapd > /dev/null 2>&1
-	then
-		$0 restart
-	else
-		log_action_msg "No slapd process found, no restart needed"
-	fi
-	;;
-  graceful-stop)
-	$0 stop
-	# logger "/etc/init.d/slapd $1 (pid: $$, ppid:$(ps -p $PPID -o pid= -o comm=))"
-	# log_action_begin_msg "Sending HUP to ldap server(s): slapd "
-	# signal_plan="HUP/10/TERM/5/KILL/1"
-	# ## first try with pidfile
-	# start-stop-daemon --stop --quiet --oknodo --retry "$signal_plan" \
-	# 	--pidfile "$pidfile" -v | sed -rn 's/.*, (retry #|refused to die)/\1/p' \
-	# 	| while read line; do log_action_cont_msg "$line"; done
-	# ## check process (instead of [ $? -eq 2 ])
-	# pid=$(pgrep -f "^$DAEMON")
-	# if [ -n "$pid" ]; then
-	# 	log_action_end_msg 1
-	# 	## try via executable name
-	# 	log_action_begin_msg "Slapd still running ($pid), sending HUP via executable name"
-	# 	start-stop-daemon --stop --quiet --oknodo --retry "$signal_plan" \
-	# 		--exec $DAEMON -v | sed -rn 's/.*, (retry #|refused to die)/\1/p' \
-	# 		| while read line; do log_action_cont_msg "$line"; done
-	# 	rm -f "$pidfile"
-	# fi
-	# log_action_end_msg 0
-	;;
-  graceful-restart)
-	$0 restart
-	# logger "/etc/init.d/slapd $1 (pid: $$, ppid:$(ps -p $PPID -o pid= -o comm=))"
-	# log_action_msg "Initiating graceful reload of ldap server(s)"
-	# $0 graceful-stop
-	# $0 start
+  status)
+	status_of_proc -p $SLAPD_PIDFILE $SLAPD slapd
 	;;
   *)
-	echo "Usage: $0 {start|stop|restart|force-stop|crestart|graceful-stop|graceful-restart}"
+  	echo "Usage: $0 {start|stop|restart|force-reload|status}"
 	exit 1
 	;;
 esac
-
-exit 0

--- a/management/univention-ldap/conffiles/etc/init.d/slapd
+++ b/management/univention-ldap/conffiles/etc/init.d/slapd
@@ -313,7 +313,7 @@ if configRegistry['ldap/server/type']=="master":
 	print '\tlog_action_end_msg 0'
 @!@
 	if [ -e /var/lib/univention-directory-replication/failed.ldif ]; then
-		log_action_begin_msg "Found failed.ldif. Importing "
+		log_action_begin_msg "Found /var/lib/univention-directory-replication/failed.ldif. Importing "
 		test -x /usr/sbin/univention-directory-replication-resync && /usr/sbin/univention-directory-replication-resync /var/lib/univention-directory-replication/failed.ldif >>/var/log/univention/listener.log 2>&1
 		if [ $? = 0 ]; then
 			log_action_end_msg 0

--- a/management/univention-ldap/conffiles/etc/init.d/slapd
+++ b/management/univention-ldap/conffiles/etc/init.d/slapd
@@ -1,4 +1,5 @@
 #!/bin/sh
+@%@UCRWARNING=# @%@
 ### BEGIN INIT INFO
 # Provides:          slapd
 # Required-Start:    $remote_fs $network $syslog
@@ -12,6 +13,135 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 
 . /lib/lsb/init-functions
+
+bdbrecover ()
+{
+	local back_bdb_version
+	local DBRECOVER
+	local DBSTAT
+	local dbstat_output
+	local dbstat_rc
+	local bdb_version
+	local stale_locks
+	local logger_tag
+	local line
+
+	log_action_begin_msg "Check database: "
+	# determine libdb version that back-bdb.so was linked against
+	back_bdb_version="$(/usr/bin/ldd /usr/lib/ldap/back_bdb.so | sed -n 's|.*/usr/lib/.*/libdb-\([0-9.]*\).so.*|\1|p')"
+	DBRECOVER="/usr/bin/db${back_bdb_version}_recover"
+	DBSTAT="/usr/bin/db${back_bdb_version}_stat"
+	if [ -e "${DBRECOVER}" ]; then
+		# check if the db_stat version works on the database environment
+		dbstat_output=$("${DBSTAT}" -h /var/lib/univention-ldap/ldap -Ne 2>&1)
+		dbstat_rc=$?
+		if [ "$dbstat_rc" = 0 ]; then
+			bdb_version=$(echo "$dbstat_output" | sed -rn 's/^([^\s]+)\s+Environment version$/\1/p')
+			if [ -n "$bdb_version" ]; then
+				# check for stale locks or stale futexes
+				stale_locks=$("${DBSTAT}" -h /var/lib/univention-ldap/ldap -Nc 2>&1 | sed -rn 's/([0-9]*)\t*Number of current locks/\1/p')
+				if [ "$stale_locks" != 0 ]; then
+					exit_if_start_is_running
+					log_action_msg "WARNING"
+					log_action_msg "WARNING: There are $stale_locks stale locks in LDAP backend Berkeley DB (version $bdb_version)"
+					log_action_msg "WARNING: If slapd does not respond, manual LDAP dump/restore may be necessary"
+					log_action_begin_msg "Continuing BDB database check: "
+				fi
+				logger_tag="slapd db${back_bdb_version}_recover"
+				dbrecover_output=$("${DBRECOVER}" -h /var/lib/univention-ldap/ldap -e 2>&1)
+				if [ "$?" != 0 ]; then
+					exit_if_start_is_running
+				else
+					echo "$dbrecover_output" | while read line; do logger -t "$logger_tag" "$line"; done
+				fi
+				log_action_end_msg 0
+			else
+				log_action_msg "/var/lib/univention-ldap/ldap BDB Version does not seem to match the one back-bdb uses"
+				log_action_msg "Skipping ${DBRECOVER} to avoid damage"
+
+				logger_tag="slapd db${back_bdb_version}_stat"
+				logger -t "$logger_tag" "BDB file version detection failed:"
+				echo "$dbstat_output" | while read line; do logger -t "$logger_tag" "$line"; done
+			fi
+		else
+			log_action_msg "Could not determine BDB version of /var/lib/univention-ldap/ldap"
+			exit_if_start_is_running
+			log_action_msg "Skipping ${DBRECOVER} to avoid damage"
+
+			logger_tag="slapd db${back_bdb_version}_stat"
+			logger -t "$logger_tag" "command failed ($dbstat_rc):"
+			echo "$dbstat_output" | while read line; do logger -t "$logger_tag" "$line"; done
+		fi
+	else
+		log_action_msg "back-bdb was linked against ${back_bdb_version}, but db${back_bdb_version}-util package does not seem to be installed"
+		log_action_msg "Skipping ${DBRECOVER}"
+	fi
+}
+
+check_subschema ()
+{
+	tmpfile=`mktemp`
+	res=1
+	count=0
+	while [ $res != 0 ] ; do
+		ldapsearch -x -H ldapi:/// -s base -b cn=Subschema 'objectClass=subschema' objectClasses attributeTypes matchingRules matchingRuleUse dITStructureRules dITContentRules nameForms ldapSyntaxes >$tmpfile
+		res=$?
+		if [ $res != 0 ]; then
+			count=$((count+1))
+			if [ $count -ge 5 ]; then
+				echo "Failed to search schema"
+				exit 1
+			fi
+			sleep 2
+		fi
+	done
+@!@
+if configRegistry.is_true('ldap/schema/export'):
+		print '\tcp $tmpfile /var/www/ldap-schema.txt'
+		print '\tchmod a+r /var/www/ldap-schema.txt'
+@!@
+	md5=`md5sum $tmpfile | awk '{print $1}'`
+	rm -f "$tmpfile"
+
+	if [ ! -d /var/lib/univention-ldap/schema ]; then
+		mkdir /var/lib/univention-ldap/schema
+	fi
+	if [ ! -e /var/lib/univention-ldap/schema/md5 ]; then
+		touch /var/lib/univention-ldap/schema/md5
+	fi
+	md5_old=`cat /var/lib/univention-ldap/schema/md5`
+	if [ "$md5" != "$md5_old" ]; then
+		if [ ! -d /var/lib/univention-ldap/schema/id ]; then
+			mkdir /var/lib/univention-ldap/schema/id
+		fi
+		if [ ! -e /var/lib/univention-ldap/schema/id/id ]; then
+			touch /var/lib/univention-ldap/schema/id/id
+		fi
+		id=`cat /var/lib/univention-ldap/schema/id/id`
+		if [ -z "$id" ]; then
+			id=0
+		fi
+		id=$((id+1))
+		echo "$md5" >/var/lib/univention-ldap/schema/md5
+		echo "$id" >/var/lib/univention-ldap/schema/id/id
+		chown listener /var/lib/univention-ldap/schema/id/id
+	else
+		id=`cat /var/lib/univention-ldap/schema/id/id`
+		if [ -z "$id" ]; then
+			echo "1" >/var/lib/univention-ldap/schema/id/id
+			chown listener /var/lib/univention-ldap/schema/id/id
+		fi
+	fi
+}
+
+check_replog_file ()
+{
+	test -f /var/lib/univention-ldap/replog/replog || \
+		touch /var/lib/univention-ldap/replog/replog
+	chmod 0600 /var/lib/univention-ldap/replog/replog
+	test -f /var/lib/univention-ldap/replog/replog.lock || \
+		touch /var/lib/univention-ldap/replog/replog.lock
+}
 
 # Kill me on all errors
 set -e
@@ -35,11 +165,12 @@ fi
 
 # Load the default location of the slapd config file
 if [ -z "$SLAPD_CONF" ]; then
-	if [ -e /etc/ldap/slapd.d ]; then
-		SLAPD_CONF=/etc/ldap/slapd.d
-	else
+	# UCS: We use slapd.d but not cn=config as configuration format
+	#if [ -e /etc/ldap/slapd.d ]; then
+	#	SLAPD_CONF=/etc/ldap/slapd.d
+	#else
 		SLAPD_CONF=/etc/ldap/slapd.conf
-	fi
+	#fi
 fi
 
 # Stop processing if the config file is not there
@@ -139,14 +270,58 @@ start_slapd() {
 		[ -z "$SLAPD_GROUP" ] || chgrp -R "$SLAPD_GROUP" "$piddir"
 	fi
 
+	# check ucr autostart setting
+	if [ -f "/usr/share/univention-config-registry/init-autostart.lib" ]; then
+		. "/usr/share/univention-config-registry/init-autostart.lib"
+		check_autostart ldap ldap/autostart
+	fi
+
+	# check that no slapd is running
+	#if ! start-stop-daemon --start --quiet --exec $DAEMON --test > /dev/null; then
+	#	log_action_msg "LDAP server already running"
+	#	exit 0
+	#fi
+@!@
+if configRegistry['ldap/database/type'] == 'bdb':
+        print '\t# check backend database'
+        print '\tbdbrecover'
+if configRegistry.get('ldap/replog', '').lower() in ('true', 'yes'):
+        print '\tcheck_replog_file'
+@!@
+	# UCS: SLAPD_SERVICE is always defined via UCR variables
+	# slapd/port and slapd/port/ldaps hence 'else' always applies.
 	if [ -z "$SLAPD_SERVICES" ]; then
 		reason="`start-stop-daemon --start --quiet --oknodo \
 			--pidfile "$SLAPD_PIDFILE" \
 			--exec $SLAPD -- $SLAPD_OPTIONS 2>&1`"
 	else
-		reason="`start-stop-daemon --start --quiet --oknodo \
+		# TODO: Maybe solve this differently today? See:
+		# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=660917
+		# https://ral-arturo.org/2017/02/14/about-process-limits.html
+@!@
+if configRegistry.get('ldap/maxopenfiles'):
+        print '\t\tulimit -n %s' % configRegistry['ldap/maxopenfiles']
+@!@		reason="`start-stop-daemon --start --quiet --oknodo \
 			--pidfile "$SLAPD_PIDFILE" \
 			--exec $SLAPD -- -h "$SLAPD_SERVICES" $SLAPD_OPTIONS 2>&1`"
+	fi
+
+@!@
+if configRegistry['ldap/server/type']=="master":
+	print '\tlog_action_begin_msg "Checking Schema ID: "'
+	print '\tcheck_subschema 2>&1'
+	print '\tlog_action_end_msg 0'
+@!@
+	if [ -e /var/lib/univention-directory-replication/failed.ldif ]; then
+		log_action_begin_msg "Found failed.ldif. Importing "
+		test -x /usr/sbin/univention-directory-replication-resync && /usr/sbin/univention-directory-replication-resync /var/lib/univention-directory-replication/failed.ldif >>/var/log/univention/listener.log 2>&1
+		if [ $? = 0 ]; then
+			log_action_end_msg 0
+		else
+			log_action_end_msg 1
+			log_action_msg "Please check /var/log/univention/listener.log"
+			exit 1
+		fi
 	fi
 
 	# Backward compatibility with OpenLDAP 2.1 client libraries.
@@ -192,11 +367,22 @@ case "$1" in
   	stop_ldap
 	start_ldap
 	;;
+  graceful-stop)
+        $0 stop
+        # UCS: In previous versions of this init script all graceful-stop did, was calling stop,
+	# nothing special otherwise. Possibly other code relies on graceful-stop to be available.
+        ;;
+  graceful-restart)
+        $0 restart
+        # UCS: In previous versions of this init script all graceful-restart did, was calling restart,
+	# nothing special otherwise. Possibly other code relies on graceful-restart to be available.
+        ;;
+
   status)
 	status_of_proc -p $SLAPD_PIDFILE $SLAPD slapd
 	;;
   *)
-  	echo "Usage: $0 {start|stop|restart|force-reload|status}"
+	echo "Usage: $0 {start|stop|restart|force-reload|status|graceful-stop|graceful-restart}"
 	exit 1
 	;;
 esac

--- a/management/univention-ldap/conffiles/etc/ldap/slapd.conf.d/30univention-ldap-server_head
+++ b/management/univention-ldap/conffiles/etc/ldap/slapd.conf.d/30univention-ldap-server_head
@@ -4,9 +4,9 @@ argsfile		/var/run/slapd/slapd.args
 loglevel		@%@ldap/debug/level@%@
 allow			bind_v2 update_anon
 
-TLSCertificateFile	/etc/univention/ssl/@%@hostname@%@.@%@domainname@%@/cert.pem
-TLSCertificateKeyFile	/etc/univention/ssl/@%@hostname@%@.@%@domainname@%@/private.key
-TLSCACertificateFile	/etc/univention/ssl/ucsCA/CAcert.pem
+TLSCertificateFile	/etc/ldap/ssl/cert.pem
+TLSCertificateKeyFile	/etc/ldap/ssl/private.key
+TLSCACertificateFile	/etc/ldap/ssl/CAcert.pem
 @!@
 ciphers = configRegistry.get("ldap/tls/ciphersuite", "HIGH:MEDIUM:!aNULL:!MD5:!RC4")
 if ciphers:

--- a/management/univention-ldap/debian/univention-ldap-server.postinst
+++ b/management/univention-ldap/debian/univention-ldap-server.postinst
@@ -132,6 +132,14 @@ ucr set \
 	ldap/shadowbind/ignorefilter?"(|(objectClass=univentionDomainController)(userPassword={KINIT}))" \
 	ldap/maxopenfiles?8192 # Bug #17705
 
+# #18500
+# Add ssl-cert group if it doesn't exist yet.
+# add user openldap to the group ssl-cert
+if [ -z "`getent group ssl-cert`" ]; then
+	addgroup --quiet --system ssl-cert
+fi
+usermod -a -G ssl-cert openldap
+
 if [ "$1" = "configure" -a -z "$2" ]; then
 	# disable anonymous bind by default
 	univention-config-registry set ldap/acl/read/anonymous?no

--- a/management/univention-ldap/debian/univention-ldap-server.univention-config-registry
+++ b/management/univention-ldap/debian/univention-ldap-server.univention-config-registry
@@ -1,8 +1,11 @@
 Type: file
-File: etc/init.d/slapd
-Variables: ldap/server/type
+File: etc/default/slapd
 Variables: slapd/port
 Variables: slapd/port/ldaps
+
+Type: file
+File: etc/init.d/slapd
+Variables: ldap/server/type
 Variables: ldap/database/type
 Variables: ldap/schema/export
 Variables: ldap/replog


### PR DESCRIPTION
- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=18500

## Description of the changes

Consider it as an attempt ad reducing the diff with Debian and working toward fix closing a 9 year old bug in UCS running slapd under as user root.

There are still some unhandled thing that I can not test or don't know how to port, there are for example:
- i686-specific startup only using BDB?
- Differences with stoping behaviour (is Debian's way now good-enough for UCS?)
- Are all parameters like crestart still needed? (maybe even the graceful ones?)
- Other leftovers?

Since the user openldap cannot read /etc/univention/ssl the certificate need to be copied to a folder with permissions for this user and group. A migration would need to be done - or maybe the init script could check their presence and copy them over if they are different? - I don't know what is going to be the best thing to do here. - Continue to run slapd as root however isn't an alternative IMHO. ;-)

* **What kind of change does this PR introduce?** Bugfix and cleanup, also security since we'd stop running slapd as user root
* **How can we reproduce the issue?** Before these changes slapd runs as user root, afterwards as unprivileged user openldap like
* **To which UCS version does the issue apply?** 4.4-1 and likely as previous reports noted likely even more than 9 years worth of UCS releases ;)
* **Please list relevant screenshots, error messages, logs or tracebacks** n/a
* **Are there any breaking or API changes?** Not API but likely update-related fixtures
* **Are there changes in the documentation necessary?** The changelog needs to have this noted.
* **Are there descriptions for newly introduced UCR variables?** No, however a new templated file is introduced.