### PR TITLE
Bug #50676: ensure backwards compatibility for nagios plugin check

### DIFF
--- a/nagios/univention-nagios-ad-connector/check_univention_ad_connector
+++ b/nagios/univention-nagios-ad-connector/check_univention_ad_connector
@@ -89,8 +89,7 @@ fi
 # check whether the AD connector is running; for this, get the exact command
 # that was used to launch the process; remove multiple whitespaces and quotes
 # in order to match the command via check_procs
-cmd=$(grep /usr/bin/python /usr/sbin/univention-ad-${CONNECTOR} | sed 's/\s\{1,\}/ /g; s/["'"'"']//g')
-/usr/lib/nagios/plugins/check_procs -w :1 -c 1: --ereg-argument-array "^${cmd}\$" >/dev/null 2>&1
+/usr/lib/nagios/plugins/check_procs -w :1 -c 1: --ereg-argument-array "^univention-ad-{CONNECTOR}(.*)\$" >/dev/null 2>&1
 ret="$?"
 
 # WARNING: if more then one instance of the same connector is running

--- a/services/univention-ad-connector/debian/control
+++ b/services/univention-ad-connector/debian/control
@@ -16,6 +16,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},
  python-univention,
  python-univention-license,
+ python-setproctitle,
  python-univention-directory-manager (>= 7.0.214),
  python-pysqlite2
 Pre-Depends: univention-config (>= 2.6.8-5)
@@ -35,6 +36,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends},
  python3-univention,
  python3-univention-license,
+ python3-setproctitle,
  python3-univention-directory-manager,
  python3-pysqlite2
 Pre-Depends: univention-config (>= 2.6.8-5)

--- a/services/univention-ad-connector/modules/univention/connector/ad/main.py
+++ b/services/univention-ad-connector/modules/univention/connector/ad/main.py
@@ -43,6 +43,7 @@ import signal
 from optparse import OptionParser
 
 import ldap
+import setproctitle
 import traceback
 import univention
 import univention.connector
@@ -94,6 +95,9 @@ def daemon(lock_file):
 			pf.write(str(pid))
 			pf.close()
 			os._exit(0)
+
+		# backwards compatibility for nagios checks not updated to UCS 4.4-3
+		setproctitle.setproctitle('univention-ad-%s # /usr/lib/pymodules/python2.7/univention/connector/ad/main.py' % CONFIGBASENAME)
 	else:
 		os._exit(0)
 


### PR DESCRIPTION
- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=50676

## Description of the changes

The nagios check for the AD connector doesn't work anymore after upgrading to UCS 4.4-3.
This commit tries to mimic what has been done to the S4 connector in #49176.

* **What kind of change does this PR introduce?** Bugfix
* **How can we reproduce the issue?** 
  * Have UCS 4.4-2 environment with Nagios and a configure AD connector
  * The Nagios check for the AD connector runs on 4.4-2 as expected
  * Upgrading to 4.4-3 renders the check unuseful since it doesn't match the provided regex in the check
* **To which UCS version does the issue apply?** 4.4-3
* **Please list relevant screenshots, error messages, logs or tracebacks** The issue has already been discussed in bugzilla.
* **Are there any breaking or API changes?** I don't think so.
* **Are there changes in the documentation necessary?** I don't think so.
* **Are there descriptions for newly introduced UCR variables?** No.
