### PR TITLE
Bug #49381: Update documentation for Server 2019 support

### DIFF
--- a/doc/manual/windows-de.xml
+++ b/doc/manual/windows-de.xml
@@ -799,7 +799,7 @@ END CATEGORY
 
 	<para>
 	  In beiden Modi wird unter UCS der Active Directory-Verbindungsdienst verwendet (kurz UCS AD-Connector), der Verzeichnisdienstobjekte zwischen einem
-	  Windows 2003/2008/2012/2016-Server mit Active Directory (AD) und dem OpenLDAP-Verzeichnis aus &ucsUCS; synchronisieren kann.
+	  Windows Server 2003-2019 mit Active Directory (AD) und dem OpenLDAP-Verzeichnis aus &ucsUCS; synchronisieren kann.
 	</para>
 
 	<para>

--- a/doc/manual/windows-en.xml
+++ b/doc/manual/windows-en.xml
@@ -761,7 +761,7 @@ END CATEGORY
 	</para>
 
 	<para>
-	  In both modes, the Active Directory Connection service is used in UCS (UCS AD Connector for short), which can synchronize the directory service objects between a Windows 2003/2008/2012/2016 server with Active Directory (AD) and the OpenLDAP directory of &ucsUCS;.
+	  In both modes, the Active Directory Connection service is used in UCS (UCS AD Connector for short), which can synchronize the directory service objects between a Windows Server 2003-2019 with Active Directory (AD) and the OpenLDAP directory of &ucsUCS;.
 	</para>
 
 	<para>

--- a/doc/scenarios/versicherung-de.xml
+++ b/doc/scenarios/versicherung-de.xml
@@ -219,7 +219,7 @@
 	<para>
 	  Der UCS Active Directory Connector (kurz AD Connector)
 	  ermöglicht eine Synchronisation von Verzeichnisdienstobjekten zwischen
-	  einem Microsoft Windows 2008/2012/2016 Server mit Microsoft Active Directory (AD) und dem
+	  einem Microsoft Windows Server 2003-2019 mit Microsoft Active Directory (AD) und dem
 	  OpenLDAP-Verzeichnisdienst in &ucsUCS;.
 	</para>
 

--- a/doc/scenarios/versicherung-en.xml
+++ b/doc/scenarios/versicherung-en.xml
@@ -208,7 +208,7 @@
 	<para>
 	  The Univention Active Directory connector (AD connector for short)
 	  makes it possible to synchronize directory service objects between a
-      Microsoft Windows 2008/2012/2016 server with Microsoft Active
+      Microsoft Windows Server 2003-2019 server with Microsoft Active
 	  Directory (AD) and an Open Source LDAP directory service in &ucsUCS;.
 	</para>
 


### PR DESCRIPTION
- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=49381

## Description of the changes

The differences between Active Directory on Server 2016 and 2019 [1] are so little to the point that support for 2019 should be granted by now - at least I hope so.

I've been using write-only mode for several months on Server 2019 and read-only in a lab setup.

[1] Windows Server Active Directory schema updates:
    https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/schema-updates

* **What kind of change does this PR introduce?** Documentation update
* **How can we reproduce the issue?** UCS 4.4-3 with AD Connector to Windows Server 2019 AD DS
* **To which UCS version does the issue apply?** 4.4-3
* **Please list relevant screenshots, error messages, logs or tracebacks** Not really applicable.
* **Are there any breaking or API changes?** No.
* **Are there changes in the documentation necessary?** Yes, that's the point of this patch.
* **Are there descriptions for newly introduced UCR variables?** No.
