### PR TITLE
Rework check_univention_replication nagios check script

### DIFF
--- a/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_replication
+++ b/nagios/univention-nagios/usr/lib/nagios/plugins/check_univention_replication
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Univention Nagios
@@ -30,180 +30,194 @@
 # /usr/share/common-licenses/AGPL-3; if not, see
 # <https://www.gnu.org/licenses/>.
 
-import commands
-import getopt
-import sys
-import pickle
+import enum
 import os
+import sys
+import traceback
+import subprocess
+import argparse
+import json
+import fcntl
+
+from datetime import datetime
+
+
+__version__ = '1.2'
+
+
+HELP = '''
+Nagios check for the replication status of UCS backup/replica directory nodes.
+
+This check will report CRITICAL if:
+ * Replication has failed (failed.ldif exists) OR
+ * The univention-directory-listener txid is behind that of the primary AND
+ * The txid has not changed since the last invocation falling between -m and -M
+
+This check will report WARNING if:
+ * No invocation history is present OR
+ * The txid is FAR (>= -w) behind the primary's, but is progressing
+
+The following cases will report OK:
+ * The listener is in sync with the primary's notifier
+ * The listener's txid is behind (< -w) the primary's, but is progressing
+'''
+
+
+class NagiosStatus(enum.Enum):
+	OK = 0
+	WARNING = 1
+	CRITICAL = 2
+	UNKNOWN = 3
+
+	def __call__(self, msg='', *args, nid=None, lid=None):
+		print(msg.format(*args), end='')
+		if nid is not None and lid is not None:
+			print(" | offset={} 'notifier id'={} 'listener id'={}".format(nid - lid, nid, lid), end='')
+		print()
+		sys.exit(self.value)
+
+
+class Parser(argparse.ArgumentParser):
+	'''
+	Nagios Check compliant command line parser:
+	Exit with code 3 (unknown) instead of 1 (critical)
+	'''
+
+	def error(self, message):
+		NagiosStatus.UNKNOWN('{}: error: {}', self.prog, message)
 
 
 class ReplicationCheck:
 
 	def __init__(self):
-		self.PROGNAME = 'check_univention_replication'
-		self.REVISION = '1.0'
 		self.FAILED_LDIF_FN = '/var/lib/univention-directory-replication/failed.ldif'
-		self.CACHEFN = '/var/lib/univention-nagios/check_univention_replication.cache'
 		self.PROG_GETNOTIFIERID = '/usr/share/univention-directory-listener/get_notifier_id.py'
 		self.PROG_GETLISTENERID = 'cat /var/lib/univention-directory-listener/notifier_id'
-		self.diff_warning = 0
-		self.diff_critical = 0
-		self.history_size = 0
-		self.verbose = 0
-
-		self.STATE = {
-			'OK': 0,
-			'WARNING': 1,
-			'CRITICAL': 2,
-			'UNKNOWN': 3
-		}
 		self.history = []
+		self.parse_args()
+		self.now = int(datetime.utcnow().timestamp())
 
-	def print_revision(self):
-		print '%s: version %s' % (self.PROGNAME, self.REVISION)
+	def vprint(self, *args, **kwargs):
+		if self.verbose:
+			print(*args, **kwargs)
 
-	def print_usage(self):
-		print 'Usage: %s [-v] [-w <cnt>] [-c <cnt>] [-n <cnt>]' % self.PROGNAME
-		print 'Usage: %s --help' % self.PROGNAME
-		print 'Usage: %s --version' % self.PROGNAME
+	def load_history(self, histfile):
+		histfile.seek(0)
+		try:
+			self.history = json.load(histfile)
+			# Prune old entries from history
+			self.history = [x for x in self.history if self.now - x[2] < self.max_age]
+			self.vprint('History loaded:', self.history)
+		except BaseException:
+			self.vprint('Loading history failed!')
 
-	def print_help(self):
-		self.print_revision()
-		print ''
-		self.print_usage()
-		print ''
-		print ' -v        verbose debug output'
-		print ' -w <cnt>  WARNING if difference of transaction IDs is >= <cnt>'
-		print ' -c <cnt>  CRITICAL if difference of transaction IDs is >= <cnt>'
-		print ' -n <cnt>  CRITICAL if no change of transaction ID over last <cnt> checks'
+	def save_history(self, histfile):
+		histfile.seek(0)
+		histfile.truncate()
+		json.dump(self.history, histfile)
+		self.vprint('History saved:', self.history)
 
-	def load_history(self):
-		if os.path.exists(self.CACHEFN) and os.stat(self.CACHEFN)[6] > 0:
-			try:
-				f = open(self.CACHEFN, 'r')
-				cnt = pickle.load(f)
-				for i in range(cnt):
-					nid = pickle.load(f)
-					lid = pickle.load(f)
-					self.history.append((nid, lid))
-				f.close()
+	def parse_args(self):
+		parser = Parser(formatter_class=argparse.RawDescriptionHelpFormatter, description=HELP)
+		parser.add_argument('--version', action='version', version=__version__)
+		parser.add_argument('-v', '--verbose', action='store_true', help='Verbose debug output')
+		parser.add_argument('-r', '--readonly', action='store_true', help='Do not modify the history file')
+		parser.add_argument('-w', '--warning',
+			type=int, metavar='cnt', dest='diff_warning', default=100,
+			help='WARNING if difference of transaction IDs is >= <cnt>')
+		parser.add_argument('-M', '--max-age',
+			type=int, metavar='seconds', dest='max_age', default=900,
+			help='Disregard and remove all history entries older than <seconds>')
+		parser.add_argument('-m', '--min-age',
+			type=int, metavar='seconds', dest='min_age', default=300,
+			help='Disregard all history entries younger than <seconds>')
+		parser.add_argument('-f', '--hist-file', '--history-file',
+			type=str, metavar='file', dest='histfn',
+			default='/var/lib/univention-nagios/adfinis_check_univention_replication.cache',
+			help='Path to the history file')
+		ns = parser.parse_args()
 
-				if self.verbose > 1:
-					print 'History loaded:', self.history
-			except:
-				if self.verbose > 1:
-					print 'Loading history failed!'
-		else:
-			if self.verbose > 1:
-				print 'History not loaded!'
-
-	def save_history(self):
-		f = open(self.CACHEFN, 'w')
-		pickle.dump(len(self.history), f)
-		for i in range(len(self.history)):
-			pickle.dump(self.history[i][0], f)
-			pickle.dump(self.history[i][1], f)
-
-		if self.verbose > 1:
-			print 'History saved:', self.history
-
-	def exit_with_status(self, state, msg, nid, lid):
-		print '%s: %s (nid=%s lid=%s)' % (state, msg, nid, lid)
-		sys.exit(self.STATE[state])
+		self.histfn = ns.histfn
+		self.diff_warning = ns.diff_warning
+		self.min_age = ns.min_age
+		self.max_age = ns.max_age
+		self.verbose = ns.verbose
+		self.readonly = ns.readonly
+		self.vprint('Options: histfn={}, diff_warning={}, max_age={}, min_age={}, readonly={}'.format(
+			self.histfn, self.diff_warning, self.max_age, self.min_age, self.readonly))
 
 	def main(self):
-		# parse command line
+
+		# get transaction ids
+		status, output = subprocess.getstatusoutput(self.PROG_GETNOTIFIERID)
+		if status:
+			NagiosStatus.WARNING('Cannot fetch notifier id. Is the notifier on the master node running? {}', output)
 		try:
-			(opts, pargs) = getopt.getopt(sys.argv[1:], 'c:hn:vw:', ['help', 'version'])
-		except:
-			self.print_usage()
-			sys.exit(self.STATE['UNKNOWN'])
+			notifier_id = int(output)
+			listener_id = int(subprocess.getoutput(self.PROG_GETLISTENERID))
+		except BaseException as e:
+			NagiosStatus.WARNING('Cannot fetch replication transaction ids: {}', e)
 
-		# get command line data
-		for opt in opts:
-			if opt[0] == '-c':
-				self.diff_critical = int(opt[1])
-				if self.diff_critical < 0:
-					self.diff_critical = 0
-			elif opt[0] == '-h' or opt[0] == '--help':
-				self.print_help()
-				sys.exit(self.STATE['UNKNOWN'])
-			elif opt[0] == '-n':
-				self.history_size = int(opt[1])
-				if self.history_size < 1:
-					self.history_size = 1
-			elif opt[0] == '-v':
-				self.verbose += 1
-			elif opt[0] == '-w':
-				self.diff_warning = int(opt[1])
-				if self.diff_warning < 0:
-					self.diff_warning = 0
-			elif opt[0] == '--version':
-				self.print_revision()
-				sys.exit(self.STATE['UNKNOWN'])
-
-		self.load_history()
-
-		# get actual transaction id
-		notifier_id = commands.getoutput(self.PROG_GETNOTIFIERID)
-		listener_id = commands.getoutput(self.PROG_GETLISTENERID)
-
-		# DEBUG CODE
-		if len(pargs) == 2:
-			notifier_id = int(pargs[0])
-			listener_id = int(pargs[1])
-
-		# add values to history
-		self.history.insert(0, (notifier_id, listener_id))
-		if len(self.history) > self.history_size:
-			del self.history[self.history_size:]
-
-		self.save_history()
+		# Update the history file while keeping a lock on the history file
+		with open(self.histfn, 'a+') as histfile:
+			fcntl.flock(histfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
+			# The file is opened with the fp at the end of they file.  If the fp is at position 0,
+			# the file was either empty or didn't exist before
+			if histfile.tell() > 0:
+				self.load_history(histfile)
+			else:
+				self.vprint('History does not exist yet')
+				self.history.insert(0, (notifier_id, listener_id, self.now))
+			if not self.readonly:
+				self.save_history(histfile)
+			fcntl.flock(histfile, fcntl.LOCK_UN)
 
 		# CRITICAL if failed.ldif exists
 		if os.path.exists(self.FAILED_LDIF_FN):
-			self.exit_with_status('CRITICAL', 'failed.ldif exists', notifier_id, listener_id)
+			NagiosStatus.CRITICAL('failed.ldif exists', nid=notifier_id, lid=listener_id)
 
+		# OK, Replication is up to date
 		if notifier_id == listener_id:
-			self.exit_with_status('OK', 'replication complete', notifier_id, listener_id)
-		else:
-			# check if listener id changed during last checks
-			change = 0
-			beenequal = 0
-			for (nid, lid) in self.history:
-				if nid == lid:
-					beenequal = 1
-				if listener_id != lid:
-					change = 1
-			if change == 0 and beenequal == 0 and len(self.history) == self.history_size:
-				self.exit_with_status('CRITICAL',
-					'no change of listener transaction id for last %s checks' % len(self.history),
-					notifier_id, listener_id)
+			NagiosStatus.OK('replication complete', nid=notifier_id, lid=listener_id)
 
-			# check if difference of nid and lid has been larger than given values
-			mindiff = None
-			for (nid, lid) in self.history:
-				diff = int(nid) - int(lid)
-				if not mindiff:
-					mindiff = diff
-				else:
-					if mindiff > diff:
-						mindiff = diff
+		# WARNING if no previous history is found - can't check, but doesn't require intervention
+		if len(self.history) == 0:
+			NagiosStatus.WARNING('Check history is empty', nid=notifier_id, lid=listener_id)
 
-			if self.verbose:
-				print 'minimal difference:', mindiff
+		# diff stays None iff the latest considered history entry is marked as in sync
+		diff = None
+		for nid, lid, ts in self.history[1:]:
+			# Disregard entries younger than min_age to cover manual check executions
+			if self.now - ts < self.min_age:
+				continue
+			# Only look at history entries since the last full sync
+			if nid == lid:
+				break
+			diff = diff or listener_id - lid > 0
+			if diff:
+				break
+		self.vprint('diff: {}'.format(diff))
 
-			if self.diff_critical and self.diff_critical <= mindiff:
-				self.exit_with_status('CRITICAL',
-					'difference was >= %s over last %s checks' % (self.diff_critical, len(self.history)),
-					notifier_id, listener_id)
-			if self.diff_warning and self.diff_warning <= mindiff:
-				self.exit_with_status('WARNING',
-					'difference was >= %s over last %s checks' % (self.diff_warning, len(self.history)),
-					notifier_id, listener_id)
+		# if change just occurred (None) or is progressing (True):
+		# Issue a WARNING if replication is too far behind, otherwise say OK
+		if diff is None or diff is True:
+			if notifier_id - listener_id >= self.diff_warning:
+				NagiosStatus.WARNING('Replication in progress, large backlog ({} transactions to go)',
+					notifier_id - listener_id, nid=notifier_id, lid=listener_id)
+			NagiosStatus.OK('Replication in progress ({} transactions to go)',
+				notifier_id - listener_id, nid=notifier_id, lid=listener_id)
 
-		self.exit_with_status('OK', 'replication is in process', notifier_id, listener_id)
+		# If none of the condiditions above match
+		NagiosStatus.CRITICAL('Replication has been stalled for at least {} s',
+			self.now - ts, nid=notifier_id, lid=listener_id)
 
 
-obj = ReplicationCheck()
-obj.main()
+if __name__ == '__main__':
+	try:
+		ReplicationCheck().main()
+	except SystemExit as e:
+		raise e
+	except:
+		# Print exception, but exit with nagios-compliant exit code
+		traceback.format_exc()
+		NagiosStatus.UNKNOWN(str(e))


### PR DESCRIPTION
Thank you for providing a pull request!

## Please make sure you considered the following things

- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=53730

## Description of the changes

We reworked the univention_replication_check nagios plugin to better fit our requirements in a large customer's environment. The primary motivation for this was that we're processing a lot of LDAP changes each night, and our on-call team was being woken up in the middle of the night, even though everything was allright, just the replication taking some time. We've been using this reworked check in production for 2 months now. As discussed with Dirk Ahrnke, we're now contributing this back to Univention:

The most significant change is the changed alerting behavior:

* This check will report CRITICAL if:
  * Replication has failed (failed.ldif exists) OR
  * The listener id is behind that of the notifier AND
  * The listener id has not changed since the last invocation falling inside the considered timeframe (between --min-age and --max-age)
* This check will report WARNING if:
  * The notifier id couldn't be fetched (a stopped notifier shouldn't trigger an alert on the affected host, but not on every single replica node) OR
  * No invocation history is present OR
  * The listener is FAR (greater than the warning threshold) behind the primary's, but is progressing
* The following cases will report OK:
  * The listener is in sync with the notifier OR
  * The listener id is behind (but less than the warning threshold) the primary's, but is progressing

In addition, we introduced the following changes:
* Use Python 3, it's 2021 after all
* Use Python's argparse module for somewhat human-readable argument parsing, rather than getopt
* Add perfdata output containing the listener id, notifier id and their difference

Note that this check is **NOT A DROP-IN REPLACEMENT** for the existing `check_univention_replication`. It uses different command line arguments, the history file uses a different format in a different place, and probably some other breaking changes:


```
usage: check_univention_replication [-h] [--version] [-v] [-r] [-w cnt] [-M seconds] [-m seconds] [-f file]

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v, --verbose         Verbose debug output
  -r, --readonly        Do not modify the history file
  -w cnt, --warning cnt
                        WARNING if difference of transaction IDs is >= <cnt>
  -M seconds, --max-age seconds
                        Disregard and remove all history entries older than <seconds>
  -m seconds, --min-age seconds
                        Disregard all history entries younger than <seconds>
  -f file, --hist-file file, --history-file file
                        Path to the history file
```
